### PR TITLE
fix: Fix Databricks SQL parser issues with COMMENT clauses (v1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.0] - 2026-01-XX
+## [1.6.1] - 2026-01-04
+
+### Fixed
+
+- **fix(sql)**: Fixed Databricks SQL parser issues with COMMENT clauses
+  - Fixed multiline COMMENT clause parsing by converting newlines to spaces within quoted strings
+  - Fixed escaped quotes in COMMENT clauses (`\'` converted to SQL standard `''`)
+  - Added support for `MAP<...>` complex types (extracted and restored like STRUCT/ARRAY)
+  - Added preprocessing to remove unsupported table-level `COMMENT` clauses
+  - Added preprocessing to remove unsupported `CLUSTER BY AUTO` clauses
+  - Improved SQL normalization to preserve quoted strings correctly
+
+### Added
+
+- **feat(sql)**: Added SQL parser test tool (`cargo run --example test_sql`)
+  - Command-line tool for manually testing SQL parsing with different dialects
+  - Supports reading from file, stdin, or command-line argument
+  - Pretty-print option for detailed column information
+  - Convenience script (`test_sql.sh`) for quick testing
+
+## [1.6.0] - 2026-01-03
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-sdk"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"
@@ -96,6 +96,10 @@ openapi = []  # Enable OpenAPI 3.1.1 import/export support (uses existing jsonsc
 [dependencies.jsonschema]
 version = "0.20"
 optional = true
+
+[[example]]
+name = "test_sql"
+path = "examples/test_sql.rs"
 
 [dev-dependencies]
 tempfile = "3"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,92 @@
+# SQL Parser Test Tool
+
+A simple CLI tool to manually test SQL parsing with different dialects.
+
+## Quick Start
+
+### Method 1: Using cargo run directly
+
+```bash
+# Parse SQL string
+cargo run --example test_sql -- --dialect databricks --sql "CREATE TABLE test (id STRING);"
+
+# Parse from file
+cargo run --example test_sql -- --dialect databricks --file test.sql --pretty
+
+# Parse from stdin
+echo "CREATE TABLE test (id STRING);" | cargo run --example test_sql -- --dialect postgres
+```
+
+### Method 2: Using the convenience script
+
+```bash
+# Parse from file
+./test_sql.sh databricks test.sql
+
+# Parse from stdin
+echo "CREATE TABLE test (id STRING);" | ./test_sql.sh databricks -
+```
+
+## Options
+
+- `-d, --dialect <DIALECT>` - SQL dialect (postgres, mysql, sqlite, generic, databricks) [default: generic]
+- `-s, --sql <SQL>` - SQL string to parse
+- `-f, --file <FILE>` - Read SQL from file
+- `-p, --pretty` - Pretty print column details (shows comments, primary keys, etc.)
+- `-h, --help` - Show help message
+
+## Examples
+
+### Test Databricks SQL with IDENTIFIER()
+
+```bash
+cargo run --example test_sql -- --dialect databricks --sql \
+  "CREATE TABLE IDENTIFIER(:catalog || '.schema.table') (id STRING, name STRING);" \
+  --pretty
+```
+
+### Test multiline COMMENT clauses
+
+```bash
+cargo run --example test_sql -- --dialect databricks --file test.sql --pretty
+```
+
+### Test different dialects
+
+```bash
+# PostgreSQL
+cargo run --example test_sql -- --dialect postgres --sql \
+  "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));" --pretty
+
+# MySQL
+cargo run --example test_sql -- --dialect mysql --sql \
+  "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));" --pretty
+
+# SQLite
+cargo run --example test_sql -- --dialect sqlite --sql \
+  "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);" --pretty
+```
+
+## Output Format
+
+The tool shows:
+- Dialect used
+- SQL input
+- Parse errors (if any)
+- Tables requiring name resolution (if any)
+- Parsed tables with column details
+- Success/failure status
+
+With `--pretty` flag, you get detailed column information including:
+- Column names and data types
+- COMMENT clauses
+- Primary key indicators
+- Nullable status
+
+## Troubleshooting
+
+If parsing fails, check:
+1. The dialect matches your SQL syntax
+2. The SQL is valid for that dialect
+3. For Databricks: ensure IDENTIFIER() expressions are properly formatted
+4. For multiline SQL: ensure quoted strings are properly closed

--- a/examples/test_sql.rs
+++ b/examples/test_sql.rs
@@ -1,0 +1,196 @@
+//! Simple CLI tool to test SQL parsing
+//!
+//! Usage:
+//!   cargo run --example test_sql -- --dialect databricks --sql "CREATE TABLE test (id STRING);"
+//!   cargo run --example test_sql -- --dialect postgres --file test.sql
+//!
+//! Or read from stdin:
+//!   echo "CREATE TABLE test (id STRING);" | cargo run --example test_sql -- --dialect databricks
+
+use data_modelling_sdk::import::sql::SQLImporter;
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let mut dialect = "generic".to_string();
+    let mut sql: Option<String> = None;
+    let mut file: Option<PathBuf> = None;
+    let mut pretty = false;
+
+    // Simple argument parsing
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--dialect" | "-d" => {
+                if i + 1 < args.len() {
+                    dialect = args[i + 1].clone();
+                    i += 2;
+                } else {
+                    eprintln!("Error: --dialect requires a value");
+                    print_usage();
+                    std::process::exit(1);
+                }
+            }
+            "--sql" | "-s" => {
+                if i + 1 < args.len() {
+                    sql = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --sql requires a value");
+                    print_usage();
+                    std::process::exit(1);
+                }
+            }
+            "--file" | "-f" => {
+                if i + 1 < args.len() {
+                    file = Some(PathBuf::from(&args[i + 1]));
+                    i += 2;
+                } else {
+                    eprintln!("Error: --file requires a value");
+                    print_usage();
+                    std::process::exit(1);
+                }
+            }
+            "--pretty" | "-p" => {
+                pretty = true;
+                i += 1;
+            }
+            "--help" | "-h" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            _ => {
+                eprintln!("Unknown argument: {}", args[i]);
+                print_usage();
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // Get SQL from file, argument, or stdin
+    let sql_content = if let Some(file_path) = file {
+        std::fs::read_to_string(&file_path)
+            .map_err(|e| format!("Failed to read file {}: {}", file_path.display(), e))?
+    } else if let Some(sql_str) = sql {
+        sql_str
+    } else {
+        // Read from stdin
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer)?;
+        buffer
+    };
+
+    if sql_content.trim().is_empty() {
+        eprintln!("Error: No SQL provided");
+        print_usage();
+        std::process::exit(1);
+    }
+
+    // Parse SQL
+    println!("Dialect: {}", dialect);
+    println!("SQL:\n{}\n", sql_content);
+    println!("{}", "=".repeat(80));
+
+    let importer = SQLImporter::new(&dialect);
+    match importer.parse(&sql_content) {
+        Ok(result) => {
+            if !result.errors.is_empty() {
+                println!("\n⚠️  Parse Errors:");
+                for error in &result.errors {
+                    println!("  - {:?}", error);
+                }
+            }
+
+            if !result.tables_requiring_name.is_empty() {
+                println!("\n⚠️  Tables Requiring Name Resolution:");
+                for table in &result.tables_requiring_name {
+                    println!("  - Table index: {}", table.table_index);
+                    if let Some(name) = &table.suggested_name {
+                        println!("    Suggested name: {}", name);
+                    }
+                }
+            }
+
+            println!("\n✅ Parsed {} table(s):", result.tables.len());
+            for (idx, table) in result.tables.iter().enumerate() {
+                println!("\nTable {}:", idx + 1);
+                println!("  Name: {:?}", table.name);
+                println!("  Columns: {}", table.columns.len());
+
+                if pretty {
+                    println!("  Column Details:");
+                    for col in &table.columns {
+                        println!("    - {} ({})", col.name, col.data_type);
+                        if let Some(desc) = &col.description {
+                            println!("      Comment: {}", desc);
+                        }
+                        if col.primary_key {
+                            println!("      Primary Key: true");
+                        }
+                        if !col.nullable {
+                            println!("      Nullable: false");
+                        }
+                    }
+                } else {
+                    // Compact output
+                    let col_names: Vec<String> = table
+                        .columns
+                        .iter()
+                        .map(|c| format!("{}:{}", c.name, c.data_type))
+                        .collect();
+                    println!("  Columns: {}", col_names.join(", "));
+                }
+            }
+
+            if result.errors.is_empty() && result.tables_requiring_name.is_empty() {
+                println!("\n✅ All checks passed!");
+            }
+        }
+        Err(e) => {
+            eprintln!("\n❌ Parse failed: {}", e);
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_usage() {
+    println!(
+        r#"
+SQL Parser Test Tool
+
+Usage:
+  cargo run --example test_sql -- [OPTIONS]
+
+Options:
+  -d, --dialect <DIALECT>    SQL dialect (postgres, mysql, sqlite, generic, databricks) [default: generic]
+  -s, --sql <SQL>            SQL string to parse
+  -f, --file <FILE>          Read SQL from file
+  -p, --pretty               Pretty print column details
+  -h, --help                 Show this help message
+
+Examples:
+  # Parse SQL string
+  cargo run --example test_sql -- --dialect databricks --sql "CREATE TABLE test (id STRING COMMENT 'test');"
+
+  # Parse from file
+  cargo run --example test_sql -- --dialect databricks --file test.sql
+
+  # Parse from stdin
+  echo "CREATE TABLE test (id STRING);" | cargo run --example test_sql -- --dialect postgres
+
+  # Pretty output
+  cargo run --example test_sql -- --dialect databricks --sql "CREATE TABLE test (id STRING, name STRING);" --pretty
+
+Supported Dialects:
+  - postgres / postgresql
+  - mysql
+  - sqlite
+  - generic (default)
+  - databricks
+"#
+    );
+}

--- a/test_sql.sh
+++ b/test_sql.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Convenience script to test SQL parsing
+# Usage: ./test_sql.sh [dialect] [sql_file or - for stdin]
+
+DIALECT="${1:-databricks}"
+SQL_INPUT="${2:-}"
+
+if [ -z "$SQL_INPUT" ] || [ "$SQL_INPUT" = "-" ]; then
+    # Read from stdin
+    cargo run --example test_sql -- --dialect "$DIALECT" --pretty
+else
+    # Read from file
+    cargo run --example test_sql -- --dialect "$DIALECT" --file "$SQL_INPUT" --pretty
+fi


### PR DESCRIPTION
## Summary

This PR fixes several issues with the Databricks SQL parser related to COMMENT clause parsing and adds support for additional Databricks-specific syntax.

## Fixes

### Issue #15: Multiline COMMENT Clauses
- **Problem**: Parser failed on multiline COMMENT clauses
- **Solution**: Convert newlines to spaces within quoted strings during normalization
- **Impact**: Multiline COMMENT clauses now parse correctly

### Escaped Quotes in COMMENT Clauses
- **Problem**: Backslash-escaped quotes (`'`) not supported by sqlparser
- **Solution**: Convert `'` to SQL standard `''` during preprocessing
- **Impact**: COMMENT clauses with escaped quotes (e.g., `customer\'s`, `aren\'t`) now work

### MAP Type Support
- **Problem**: `MAP<STRING, STRING>` types caused parse errors
- **Solution**: Added MAP to complex type extraction (like STRUCT/ARRAY)
- **Impact**: MAP types are now extracted and restored correctly

### Table-Level COMMENT Clauses
- **Problem**: sqlparser doesn't support table-level `COMMENT "text"` clauses
- **Solution**: Remove table-level COMMENT clauses during preprocessing
- **Impact**: Tables with table-level COMMENT clauses now parse successfully

### CLUSTER BY AUTO Clause
- **Problem**: sqlparser doesn't support `CLUSTER BY AUTO` clause
- **Solution**: Remove CLUSTER BY clauses during preprocessing
- **Impact**: Databricks tables with CLUSTER BY now parse successfully

## Added

### SQL Parser Test Tool
- New example: `cargo run --example test_sql`
- Convenience script: `./test_sql.sh`
- Supports file, stdin, and command-line SQL input
- Pretty-print option for detailed output
- Useful for manual testing and debugging

## Testing

- ✅ All existing tests pass
- ✅ New test for escaped quotes in COMMENT clauses
- ✅ Tested with real-world Databricks SQL (gam.sql)
- ✅ Verified backward compatibility

## Version

Bumped version to **1.6.1** (patch release)

## Related Issues

Fixes #15

## Checklist

- [x] All tests pass
- [x] Code formatted with `cargo fmt`
- [x] Linting passes with `cargo clippy`
- [x] CHANGELOG updated
- [x] Version bumped in Cargo.toml
- [x] Backward compatibility verified