### PR TITLE
feat(json-schema): Add full JSON Schema validation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-01-04
+
+### Added
+
+- **feat(json-schema)**: Full JSON Schema validation support
+  - Import: Extract all JSON Schema validation keywords (pattern, minimum, maximum, minLength, maxLength, enum, const, multipleOf, minItems, maxItems, uniqueItems, minProperties, maxProperties, allOf, anyOf, oneOf, not)
+  - Export: Export validation conditions from Column quality rules and enum_values back to JSON Schema format
+  - Added enum_values field to ColumnData structure to preserve enumeration values through import pipeline
+  - Validation keywords stored as quality rules with source="json_schema" for proper round-trip preservation
+  - Comprehensive integration test for validation conditions round-trip
+
 ## [1.6.1] - 2026-01-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-sdk"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/src/import/avro.rs
+++ b/src/import/avro.rs
@@ -87,6 +87,11 @@ impl AvroImporter {
                                     Some(c.quality.clone())
                                 },
                                 ref_path: c.ref_path.clone(),
+                                enum_values: if c.enum_values.is_empty() {
+                                    None
+                                } else {
+                                    Some(c.enum_values.clone())
+                                },
                             })
                             .collect(),
                     });

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -87,6 +87,9 @@ pub struct ColumnData {
     /// JSON Schema $ref reference path (from ODCS/ODCL $ref field)
     #[serde(skip_serializing_if = "Option::is_none", rename = "$ref")]
     pub ref_path: Option<String>,
+    /// Enum values if this column is an enumeration type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<String>>,
 }
 
 // Re-export for convenience

--- a/src/import/odcs.rs
+++ b/src/import/odcs.rs
@@ -98,6 +98,11 @@ impl ODCSImporter {
                                 Some(c.quality.clone())
                             },
                             ref_path: c.ref_path.clone(),
+                            enum_values: if c.enum_values.is_empty() {
+                                None
+                            } else {
+                                Some(c.enum_values.clone())
+                            },
                         })
                         .collect(),
                 }];

--- a/src/import/protobuf.rs
+++ b/src/import/protobuf.rs
@@ -101,6 +101,11 @@ impl ProtobufImporter {
                                     Some(c.quality.clone())
                                 },
                                 ref_path: c.ref_path.clone(),
+                                enum_values: if c.enum_values.is_empty() {
+                                    None
+                                } else {
+                                    Some(c.enum_values.clone())
+                                },
                             })
                             .collect(),
                     });

--- a/src/import/sql.rs
+++ b/src/import/sql.rs
@@ -903,6 +903,7 @@ impl SQLImporter {
                 description,
                 quality: None,
                 ref_path: None,
+                enum_values: None,
             });
         }
 


### PR DESCRIPTION
- Import: Extract all JSON Schema validation keywords (pattern, minimum, maximum, minLength, maxLength, enum, const, multipleOf, minItems, maxItems, uniqueItems, minProperties, maxProperties, allOf, anyOf, oneOf, not)
- Export: Export validation conditions from Column quality rules and enum_values back to JSON Schema format
- Added enum_values field to ColumnData structure to preserve enumeration values through import pipeline
- Validation keywords stored as quality rules with source="json_schema" for proper round-trip preservation
- Comprehensive integration test for validation conditions round-trip

Version bump: 1.6.1 -> 1.6.2