### PR TITLE
fix(validation): move schema validation from CLI to core validation m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-01-07
+
+### Fixed
+
+- **fix(validation)**: Move schema validation from CLI module to core validation module
+  - Schema validation functions are now in `validation::schema` instead of `cli::validation`
+  - Fixes WASM build failure when `cli` feature is not enabled but `schema-validation` is
+  - Validation functions are now available to all SDK consumers (WASM, native, API)
+  - Removed duplicate inline validation code from import/export modules
+  - Removed redundant `cli/validation.rs` wrapper module
+
 ## [1.13.0] - 2026-01-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-sdk"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/src/bin/test-odps.rs
+++ b/src/bin/test-odps.rs
@@ -159,31 +159,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Validate if enabled
     if !args.no_validate {
         println!("🔍 Validating ODPS schema...");
-        #[cfg(feature = "cli")]
-        {
-            use data_modelling_sdk::cli::validation::validate_odps;
-            validate_odps(&content).map_err(|e| format!("Validation failed: {}", e))?;
-        }
-        #[cfg(not(feature = "cli"))]
-        {
-            // Inline validation
-            use jsonschema::Validator;
-            use serde_json::Value;
-
-            let schema_content = include_str!("../../schemas/odps-json-schema-latest.json");
-            let schema: Value = serde_json::from_str(schema_content)
-                .map_err(|e| format!("Failed to load ODPS schema: {}", e))?;
-
-            let validator = Validator::new(&schema)
-                .map_err(|e| format!("Failed to compile ODPS schema: {}", e))?;
-
-            let data: Value = serde_yaml::from_str(&content)
-                .map_err(|e| format!("Failed to parse YAML: {}", e))?;
-
-            if let Err(error) = validator.validate(&data) {
-                return Err(format!("ODPS validation failed: {}", error).into());
-            }
-        }
+        use data_modelling_sdk::validation::schema::validate_odps_internal;
+        validate_odps_internal(&content).map_err(|e| format!("Validation failed: {}", e))?;
         println!("✅ Validation passed");
     } else {
         println!("⚠️  Validation skipped (--no-validate)");
@@ -210,32 +187,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Validate exported YAML if enabled
     if !args.no_validate {
         println!("🔍 Validating exported YAML...");
-        #[cfg(feature = "cli")]
-        {
-            use data_modelling_sdk::cli::validation::validate_odps;
-            validate_odps(&exported_yaml)
-                .map_err(|e| format!("Exported YAML validation failed: {}", e))?;
-        }
-        #[cfg(not(feature = "cli"))]
-        {
-            // Inline validation
-            use jsonschema::Validator;
-            use serde_json::Value;
-
-            let schema_content = include_str!("../../schemas/odps-json-schema-latest.json");
-            let schema: Value = serde_json::from_str(schema_content)
-                .map_err(|e| format!("Failed to load ODPS schema: {}", e))?;
-
-            let validator = Validator::new(&schema)
-                .map_err(|e| format!("Failed to compile ODPS schema: {}", e))?;
-
-            let data: Value = serde_yaml::from_str(&exported_yaml)
-                .map_err(|e| format!("Failed to parse exported YAML: {}", e))?;
-
-            if let Err(error) = validator.validate(&data) {
-                return Err(format!("Exported YAML validation failed: {}", error).into());
-            }
-        }
+        use data_modelling_sdk::validation::schema::validate_odps_internal;
+        validate_odps_internal(&exported_yaml)
+            .map_err(|e| format!("Exported YAML validation failed: {}", e))?;
         println!("✅ Exported YAML validation passed");
     }
 

--- a/src/cli/commands/validate.rs
+++ b/src/cli/commands/validate.rs
@@ -1,10 +1,12 @@
 //! Validate command implementation
 
 use crate::cli::error::CliError;
-use crate::cli::validation::{
-    validate_avro, validate_cads, validate_decision, validate_decisions_index,
-    validate_json_schema, validate_knowledge, validate_knowledge_index, validate_odcl,
-    validate_odcs, validate_odps, validate_openapi, validate_protobuf, validate_sql,
+use crate::validation::schema::{
+    validate_avro_internal, validate_cads_internal, validate_decision_internal,
+    validate_decisions_index_internal, validate_json_schema_internal,
+    validate_knowledge_index_internal, validate_knowledge_internal, validate_odcl_internal,
+    validate_odcs_internal, validate_odps_internal, validate_openapi_internal,
+    validate_protobuf_internal, validate_sql_internal,
 };
 use std::io::Read;
 use std::path::PathBuf;
@@ -29,27 +31,29 @@ fn load_input(input: &str) -> Result<String, CliError> {
 pub fn handle_validate(format: &str, input: &str) -> Result<(), CliError> {
     let content = load_input(input)?;
 
-    match format {
-        "odcs" => validate_odcs(&content)?,
-        "odcl" => validate_odcl(&content)?,
-        "odps" => validate_odps(&content)?,
-        "cads" => validate_cads(&content)?,
-        "openapi" => validate_openapi(&content)?,
-        "protobuf" => validate_protobuf(&content)?,
-        "avro" => validate_avro(&content)?,
-        "json-schema" => validate_json_schema(&content)?,
-        "sql" => validate_sql(&content)?,
-        "decision" => validate_decision(&content)?,
-        "knowledge" => validate_knowledge(&content)?,
-        "decisions-index" => validate_decisions_index(&content)?,
-        "knowledge-index" => validate_knowledge_index(&content)?,
+    let result = match format {
+        "odcs" => validate_odcs_internal(&content),
+        "odcl" => validate_odcl_internal(&content),
+        "odps" => validate_odps_internal(&content),
+        "cads" => validate_cads_internal(&content),
+        "openapi" => validate_openapi_internal(&content),
+        "protobuf" => validate_protobuf_internal(&content),
+        "avro" => validate_avro_internal(&content),
+        "json-schema" => validate_json_schema_internal(&content),
+        "sql" => validate_sql_internal(&content),
+        "decision" => validate_decision_internal(&content),
+        "knowledge" => validate_knowledge_internal(&content),
+        "decisions-index" => validate_decisions_index_internal(&content),
+        "knowledge-index" => validate_knowledge_index_internal(&content),
         _ => {
             return Err(CliError::InvalidArgument(format!(
                 "Unknown format: {}",
                 format
             )));
         }
-    }
+    };
+
+    result.map_err(CliError::ValidationError)?;
 
     println!("Validation successful");
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,8 +8,6 @@ pub mod error;
 pub mod output;
 #[cfg(feature = "cli")]
 pub mod reference;
-#[cfg(feature = "cli")]
-pub mod validation;
 
 #[cfg(feature = "cli")]
 pub use error::CliError;

--- a/src/export/avro.rs
+++ b/src/export/avro.rs
@@ -40,18 +40,10 @@ impl AvroExporter {
             .map_err(|e| ExportError::SerializationError(e.to_string()))?;
 
         // Validate exported AVRO schema
-        #[cfg(feature = "cli")]
         {
-            use crate::cli::validation::validate_avro;
-            validate_avro(&content).map_err(|e| {
+            use crate::validation::schema::validate_avro_internal;
+            validate_avro_internal(&content).map_err(|e| {
                 ExportError::ValidationError(format!("AVRO validation failed: {}", e))
-            })?;
-        }
-        #[cfg(not(feature = "cli"))]
-        {
-            // Basic validation - parse as JSON and check for required AVRO fields
-            let _value: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
-                ExportError::ValidationError(format!("Failed to parse AVRO JSON: {}", e))
             })?;
         }
 

--- a/src/export/cads.rs
+++ b/src/export/cads.rs
@@ -25,37 +25,8 @@ impl CADSExporter {
         // Validate exported YAML against CADS schema (if feature enabled)
         #[cfg(feature = "schema-validation")]
         {
-            #[cfg(feature = "cli")]
-            {
-                use crate::cli::validation::validate_cads_internal;
-                validate_cads_internal(&yaml).map_err(ExportError::ValidationError)?;
-            }
-            #[cfg(not(feature = "cli"))]
-            {
-                // Inline validation when CLI feature is not enabled
-                use jsonschema::Validator;
-                use serde_json::Value;
-
-                let schema_content = include_str!("../../schemas/cads.schema.json");
-                let schema: Value = serde_json::from_str(schema_content).map_err(|e| {
-                    ExportError::ValidationError(format!("Failed to load CADS schema: {}", e))
-                })?;
-
-                let validator = Validator::new(&schema).map_err(|e| {
-                    ExportError::ValidationError(format!("Failed to compile CADS schema: {}", e))
-                })?;
-
-                let data: Value = serde_yaml::from_str(&yaml).map_err(|e| {
-                    ExportError::ValidationError(format!("Failed to parse YAML: {}", e))
-                })?;
-
-                if let Err(error) = validator.validate(&data) {
-                    return Err(ExportError::ValidationError(format!(
-                        "CADS validation failed: {}",
-                        error
-                    )));
-                }
-            }
+            use crate::validation::schema::validate_cads_internal;
+            validate_cads_internal(&yaml).map_err(ExportError::ValidationError)?;
         }
 
         Ok(yaml)

--- a/src/export/decision.rs
+++ b/src/export/decision.rs
@@ -31,11 +31,8 @@ impl DecisionExporter {
         // Validate exported YAML against decision schema (if feature enabled)
         #[cfg(feature = "schema-validation")]
         {
-            #[cfg(feature = "cli")]
-            {
-                use crate::cli::validation::validate_decision_internal;
-                validate_decision_internal(&yaml).map_err(ExportError::ValidationError)?;
-            }
+            use crate::validation::schema::validate_decision_internal;
+            validate_decision_internal(&yaml).map_err(ExportError::ValidationError)?;
         }
 
         Ok(yaml)

--- a/src/export/json_schema.rs
+++ b/src/export/json_schema.rs
@@ -54,28 +54,10 @@ impl JSONSchemaExporter {
         // Validate exported JSON Schema (if feature enabled)
         #[cfg(feature = "schema-validation")]
         {
-            #[cfg(feature = "cli")]
-            {
-                use crate::cli::validation::validate_json_schema;
-                validate_json_schema(&content).map_err(|e| {
-                    ExportError::ValidationError(format!("JSON Schema validation failed: {}", e))
-                })?;
-            }
-            #[cfg(not(feature = "cli"))]
-            {
-                // Inline validation when CLI feature is not enabled
-                use jsonschema::Validator;
-                use serde_json::Value;
-
-                let schema_value: Value = serde_json::from_str(&content).map_err(|e| {
-                    ExportError::ValidationError(format!("Failed to parse JSON Schema: {}", e))
-                })?;
-
-                // Try to compile the schema (this validates the schema itself)
-                Validator::new(&schema_value).map_err(|e| {
-                    ExportError::ValidationError(format!("Invalid JSON Schema: {}", e))
-                })?;
-            }
+            use crate::validation::schema::validate_json_schema_internal;
+            validate_json_schema_internal(&content).map_err(|e| {
+                ExportError::ValidationError(format!("JSON Schema validation failed: {}", e))
+            })?;
         }
 
         Ok(ExportResult {

--- a/src/export/knowledge.rs
+++ b/src/export/knowledge.rs
@@ -31,11 +31,8 @@ impl KnowledgeExporter {
         // Validate exported YAML against knowledge schema (if feature enabled)
         #[cfg(feature = "schema-validation")]
         {
-            #[cfg(feature = "cli")]
-            {
-                use crate::cli::validation::validate_knowledge_internal;
-                validate_knowledge_internal(&yaml).map_err(ExportError::ValidationError)?;
-            }
+            use crate::validation::schema::validate_knowledge_internal;
+            validate_knowledge_internal(&yaml).map_err(ExportError::ValidationError)?;
         }
 
         Ok(yaml)

--- a/src/export/odcs.rs
+++ b/src/export/odcs.rs
@@ -1756,42 +1756,10 @@ impl ODCSExporter {
             // Validate exported YAML against ODCS schema (if feature enabled)
             #[cfg(feature = "schema-validation")]
             {
-                #[cfg(feature = "cli")]
-                {
-                    use crate::cli::validation::validate_odcs;
-                    validate_odcs(&yaml).map_err(|e| {
-                        ExportError::ValidationError(format!("ODCS validation failed: {}", e))
-                    })?;
-                }
-                #[cfg(not(feature = "cli"))]
-                {
-                    // Inline validation when CLI feature is not enabled
-                    use jsonschema::Validator;
-                    use serde_json::Value;
-
-                    let schema_content = include_str!("../../schemas/odcs-json-schema-v3.1.0.json");
-                    let schema: Value = serde_json::from_str(schema_content).map_err(|e| {
-                        ExportError::ValidationError(format!("Failed to load ODCS schema: {}", e))
-                    })?;
-
-                    let validator = Validator::new(&schema).map_err(|e| {
-                        ExportError::ValidationError(format!(
-                            "Failed to compile ODCS schema: {}",
-                            e
-                        ))
-                    })?;
-
-                    let data: Value = serde_yaml::from_str(&yaml).map_err(|e| {
-                        ExportError::ValidationError(format!("Failed to parse YAML: {}", e))
-                    })?;
-
-                    if let Err(error) = validator.validate(&data) {
-                        return Err(ExportError::ValidationError(format!(
-                            "ODCS validation failed: {}",
-                            error
-                        )));
-                    }
-                }
+                use crate::validation::schema::validate_odcs_internal;
+                validate_odcs_internal(&yaml).map_err(|e| {
+                    ExportError::ValidationError(format!("ODCS validation failed: {}", e))
+                })?;
             }
 
             exports.insert(

--- a/src/import/decision.rs
+++ b/src/import/decision.rs
@@ -7,7 +7,7 @@ use super::ImportError;
 use crate::models::decision::{Decision, DecisionIndex};
 
 #[cfg(feature = "schema-validation")]
-use crate::cli::validation::validate_decision_internal;
+use crate::validation::schema::validate_decision_internal;
 
 /// Decision importer for parsing MADR-compliant YAML files
 pub struct DecisionImporter;

--- a/src/import/knowledge.rs
+++ b/src/import/knowledge.rs
@@ -7,7 +7,7 @@ use super::ImportError;
 use crate::models::knowledge::{KnowledgeArticle, KnowledgeIndex};
 
 #[cfg(feature = "schema-validation")]
-use crate::cli::validation::validate_knowledge_internal;
+use crate::validation::schema::validate_knowledge_internal;
 
 /// Knowledge importer for parsing Knowledge Base article YAML files
 pub struct KnowledgeImporter;

--- a/src/import/odps.rs
+++ b/src/import/odps.rs
@@ -62,37 +62,8 @@ impl ODPSImporter {
         // Validate against ODPS schema before parsing (if feature enabled)
         #[cfg(feature = "odps-validation")]
         {
-            #[cfg(feature = "cli")]
-            {
-                use crate::cli::validation::validate_odps_internal;
-                validate_odps_internal(yaml_content).map_err(ImportError::ValidationError)?;
-            }
-            #[cfg(not(feature = "cli"))]
-            {
-                // Inline validation when CLI feature is not enabled
-                use jsonschema::Validator;
-                use serde_json::Value;
-
-                let schema_content = include_str!("../../schemas/odps-json-schema-latest.json");
-                let schema: Value = serde_json::from_str(schema_content).map_err(|e| {
-                    ImportError::ValidationError(format!("Failed to load ODPS schema: {}", e))
-                })?;
-
-                let validator = Validator::new(&schema).map_err(|e| {
-                    ImportError::ValidationError(format!("Failed to compile ODPS schema: {}", e))
-                })?;
-
-                let data: Value = serde_yaml::from_str(yaml_content).map_err(|e| {
-                    ImportError::ValidationError(format!("Failed to parse YAML: {}", e))
-                })?;
-
-                if let Err(error) = validator.validate(&data) {
-                    return Err(ImportError::ValidationError(format!(
-                        "ODPS validation failed: {}",
-                        error
-                    )));
-                }
-            }
+            use crate::validation::schema::validate_odps_internal;
+            validate_odps_internal(yaml_content).map_err(ImportError::ValidationError)?;
         }
 
         let yaml_value: YamlValue = serde_yaml::from_str(yaml_content)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,35 +639,8 @@ mod wasm {
     #[cfg(feature = "odps-validation")]
     #[wasm_bindgen]
     pub fn validate_odps(yaml_content: &str) -> Result<(), JsValue> {
-        #[cfg(feature = "cli")]
-        {
-            use crate::cli::validation::validate_odps_internal;
-            validate_odps_internal(yaml_content).map_err(validation_error)
-        }
-        #[cfg(not(feature = "cli"))]
-        {
-            // Inline validation when CLI feature is not enabled
-            use jsonschema::Validator;
-            use serde_json::Value;
-
-            let schema_content = include_str!("../schemas/odps-json-schema-latest.json");
-            let schema: Value = serde_json::from_str(schema_content)
-                .map_err(|e| validation_error(format!("Failed to load ODPS schema: {}", e)))?;
-
-            let validator = Validator::new(&schema)
-                .map_err(|e| validation_error(format!("Failed to compile ODPS schema: {}", e)))?;
-
-            let data: Value = serde_yaml::from_str(yaml_content).map_err(parse_error)?;
-
-            if let Err(error) = validator.validate(&data) {
-                return Err(validation_error(format!(
-                    "ODPS validation failed: {}",
-                    error
-                )));
-            }
-
-            Ok(())
-        }
+        use crate::validation::schema::validate_odps_internal;
+        validate_odps_internal(yaml_content).map_err(validation_error)
     }
 
     #[cfg(not(feature = "odps-validation"))]

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -4,9 +4,11 @@
 //! - Table validation (naming conflicts, pattern exclusivity)
 //! - Relationship validation (circular dependencies)
 //! - Input validation and sanitization (security)
+//! - JSON Schema validation for various file formats (ODCS, ODCL, Decision, Knowledge, etc.)
 
 pub mod input;
 pub mod relationships;
+pub mod schema;
 pub mod tables;
 pub mod xml;
 
@@ -16,5 +18,13 @@ pub use input::{
     validate_uuid,
 };
 pub use relationships::{RelationshipValidationError, RelationshipValidationResult};
+pub use schema::{
+    validate_avro_internal, validate_cads_internal, validate_decision_internal,
+    validate_decisions_index_internal, validate_json_schema_internal,
+    validate_knowledge_index_internal, validate_knowledge_internal, validate_odcl_internal,
+    validate_odcs_internal, validate_odps_internal, validate_openapi_internal,
+    validate_protobuf_internal, validate_relationships_internal, validate_sql_internal,
+    validate_workspace_internal,
+};
 pub use tables::{TableValidationError, TableValidationResult};
 pub use xml::{load_xsd_schema, validate_xml_against_xsd};


### PR DESCRIPTION
…odule

- Schema validation functions are now in validation::schema instead of cli::validation
- Fixes WASM build failure when cli feature is not enabled but schema-validation is
- Validation functions are now available to all SDK consumers (WASM, native, API)
- Removed duplicate inline validation code from import/export modules
- Removed redundant cli/validation.rs wrapper module

Bumps version to 1.13.1