### PR TITLE
feat(import): preserve all ODCS contract fields and add system refs (#34, #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.5] - 2026-01-08
+
+### Added
+
+- **feat(import)**: Preserve all ODCS v3.1.0 contract-level fields during import (#35)
+  - `TableData` struct now includes: `id`, `apiVersion`, `version`, `status`, `kind`, `domain`, `dataProduct`, `tenant`, `description`, `servers`, `team`, `support`, `roles`, `slaProperties`, `quality`, `price`, `tags`, `customProperties`, `authoritativeDefinitions`, `contractCreatedTs`, `odcsMetadata`
+  - ODCS and ODCL importers extract all fields from source YAML
+  - Other importers (Avro, JSON Schema, Protobuf, SQL) use defaults for ODCS-specific fields
+
+- **feat(workspace)**: Add `table_ids` and `asset_ids` to SystemReference (#34)
+  - Optional UUID arrays for explicit table-to-system and asset-to-system mapping
+  - Enables direct relationships without relying on `customProperties.system_id`
+  - Updated workspace JSON schema and Rust types
+
+### Fixed
+
+- **fix(import)**: ODCS `id` field now correctly preserved in import results (#35)
+  - Previously the contract UUID was extracted but lost during `TableData` construction
+  - Tables now retain their source UUIDs for proper system linkage
+
 ## [1.13.4] - 2026-01-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-sdk"
-version = "1.13.4"
+version = "1.13.5"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/schemas/workspace-schema.json
+++ b/schemas/workspace-schema.json
@@ -103,6 +103,22 @@
         "description": {
           "type": "string",
           "description": "Optional description of the system"
+        },
+        "table_ids": {
+          "type": "array",
+          "description": "Optional array of table UUIDs that belong to this system. When present, provides explicit table-to-system mapping without requiring parsing of individual ODCS files.",
+          "items": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "asset_ids": {
+          "type": "array",
+          "description": "Optional array of compute asset (CADS) UUIDs that belong to this system. When present, provides explicit asset-to-system mapping.",
+          "items": {
+            "type": "string",
+            "format": "uuid"
+          }
         }
       },
       "additionalProperties": false

--- a/src/cli/commands/import.rs
+++ b/src/cli/commands/import.rs
@@ -1465,8 +1465,10 @@ fn handle_import_protobuf_from_jar(args: &ImportArgs, jar_path: &PathBuf) -> Res
     // Create a single table from flattened columns
     let table_data = TableData {
         table_index: 0,
+        id: None, // Protobuf imports don't have UUIDs - generated later during model creation
         name: Some(root_message_name.clone()),
         columns,
+        ..Default::default()
     };
 
     let result = ImportResult {
@@ -1587,12 +1589,14 @@ pub fn handle_import_openapi(args: &ImportArgs) -> Result<(), CliError> {
                 Ok(table) => {
                     tables.push(crate::import::TableData {
                         table_index: tables.len(),
+                        id: Some(table.id.to_string()),
                         name: Some(table.name.clone()),
                         columns: table
                             .columns
                             .iter()
                             .map(crate::import::odcs_shared::column_to_column_data)
                             .collect(),
+                        ..Default::default()
                     });
                 }
                 Err(e) => {

--- a/src/convert/converter.rs
+++ b/src/convert/converter.rs
@@ -433,6 +433,7 @@ mod tests {
         let import_result = ImportResult {
             tables: vec![TableData {
                 table_index: 0,
+                id: Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
                 name: Some("users".to_string()),
                 columns: vec![
                     ColumnData {
@@ -450,6 +451,7 @@ mod tests {
                         ..Default::default()
                     },
                 ],
+                ..Default::default()
             }],
             tables_requiring_name: vec![],
             errors: vec![],
@@ -504,6 +506,7 @@ mod tests {
                     primary_key: true,
                     ..Default::default()
                 }],
+                ..Default::default()
             }],
             tables_requiring_name: vec![],
             errors: vec![],

--- a/src/import/avro.rs
+++ b/src/import/avro.rs
@@ -68,8 +68,10 @@ impl AvroImporter {
                 for (idx, table) in tables.iter().enumerate() {
                     sdk_tables.push(TableData {
                         table_index: idx,
+                        id: Some(table.id.to_string()),
                         name: Some(table.name.clone()),
                         columns: table.columns.iter().map(column_to_column_data).collect(),
+                        ..Default::default()
                     });
                 }
                 let sdk_errors: Vec<ImportError> = errors

--- a/src/import/json_schema.rs
+++ b/src/import/json_schema.rs
@@ -95,8 +95,10 @@ impl JSONSchemaImporter {
                 for (idx, table) in tables.iter().enumerate() {
                     sdk_tables.push(TableData {
                         table_index: idx,
+                        id: Some(table.id.to_string()),
                         name: Some(table.name.clone()),
                         columns: table.columns.iter().map(column_to_column_data).collect(),
+                        ..Default::default()
                     });
                 }
                 let sdk_errors: Vec<ImportError> = errors

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -68,13 +68,103 @@ pub enum ImportError {
     OpenAPIParseError(String),
 }
 
-/// Table data from import
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// Table data from import - preserves all ODCS v3.1.0 contract-level fields
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TableData {
+    /// Index of this table in the import result
     pub table_index: usize,
+
+    // === ODCS Contract Identity Fields ===
+    /// Table/Contract UUID from ODCS `id` field (preserved from source file)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Contract/table name (ODCS: name)
     pub name: Option<String>,
+    /// ODCS API version (e.g., "v3.1.0")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+    /// Contract version (ODCS: version)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Contract status (ODCS: status) - e.g., "draft", "active", "deprecated"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Contract kind (ODCS: kind) - typically "DataContract"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+
+    // === Domain & Organization ===
+    /// Domain name (ODCS: domain)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    /// Data product name (ODCS: dataProduct)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_product: Option<String>,
+    /// Tenant identifier (ODCS: tenant)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+
+    // === Description (ODCS description object) ===
+    /// High-level description object containing usage, purpose, limitations
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<serde_json::Value>,
+
+    // === Schema/Columns ===
+    /// Column definitions (from ODCS schema.properties)
     pub columns: Vec<ColumnData>,
-    // Additional fields can be added as needed
+
+    // === Server Configuration ===
+    /// Server definitions (ODCS: servers)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub servers: Vec<serde_json::Value>,
+
+    // === Team & Support ===
+    /// Team information (ODCS: team)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team: Option<serde_json::Value>,
+    /// Support information (ODCS: support)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub support: Option<serde_json::Value>,
+
+    // === Roles & Access ===
+    /// Role definitions (ODCS: roles)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<serde_json::Value>,
+
+    // === SLA & Quality ===
+    /// SLA properties (ODCS: slaProperties)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sla_properties: Vec<serde_json::Value>,
+    /// Contract-level quality rules
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub quality: Vec<std::collections::HashMap<String, serde_json::Value>>,
+
+    // === Pricing ===
+    /// Pricing information (ODCS: price)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<serde_json::Value>,
+
+    // === Tags & Custom Properties ===
+    /// Contract-level tags (ODCS: tags)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// Custom properties (ODCS: customProperties)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_properties: Vec<serde_json::Value>,
+    /// Authoritative definitions (ODCS: authoritativeDefinitions)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authoritative_definitions: Vec<serde_json::Value>,
+
+    // === Timestamps ===
+    /// Contract creation timestamp (ODCS: contractCreatedTs)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_created_ts: Option<String>,
+
+    // === Legacy/Metadata Storage ===
+    /// Additional ODCS metadata not captured in specific fields (for backward compatibility)
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub odcs_metadata: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Column data from import - mirrors Column struct exactly to preserve all ODCS v3.1.0 fields

--- a/src/import/protobuf.rs
+++ b/src/import/protobuf.rs
@@ -82,8 +82,10 @@ impl ProtobufImporter {
                 for (idx, table) in tables.iter().enumerate() {
                     sdk_tables.push(TableData {
                         table_index: idx,
+                        id: Some(table.id.to_string()),
                         name: Some(table.name.clone()),
                         columns: table.columns.iter().map(column_to_column_data).collect(),
+                        ..Default::default()
                     });
                 }
                 let sdk_errors: Vec<ImportError> = errors

--- a/src/import/sql.rs
+++ b/src/import/sql.rs
@@ -985,8 +985,10 @@ impl SQLImporter {
         Ok((
             TableData {
                 table_index,
+                id: None, // SQL imports don't have UUIDs - generated later during model creation
                 name: Some(table_name),
                 columns: out_cols,
+                ..Default::default()
             },
             requires_name,
         ))
@@ -1030,8 +1032,10 @@ impl SQLImporter {
         Ok((
             TableData {
                 table_index: view_index,
+                id: None, // SQL imports don't have UUIDs - generated later during model creation
                 name: Some(view_name),
                 columns: Vec::new(), // Views don't have explicit column definitions
+                ..Default::default()
             },
             requires_name,
         ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,8 +282,29 @@ mod wasm {
 
                 TableData {
                     table_index: table_data.table_index,
-                    name: table_data.name,
+                    id: table_data.id.clone(),
+                    name: table_data.name.clone(),
                     columns: all_columns,
+                    api_version: table_data.api_version.clone(),
+                    version: table_data.version.clone(),
+                    status: table_data.status.clone(),
+                    kind: table_data.kind.clone(),
+                    domain: table_data.domain.clone(),
+                    data_product: table_data.data_product.clone(),
+                    tenant: table_data.tenant.clone(),
+                    description: table_data.description.clone(),
+                    servers: table_data.servers.clone(),
+                    team: table_data.team.clone(),
+                    support: table_data.support.clone(),
+                    roles: table_data.roles.clone(),
+                    sla_properties: table_data.sla_properties.clone(),
+                    quality: table_data.quality.clone(),
+                    price: table_data.price.clone(),
+                    tags: table_data.tags.clone(),
+                    custom_properties: table_data.custom_properties.clone(),
+                    authoritative_definitions: table_data.authoritative_definitions.clone(),
+                    contract_created_ts: table_data.contract_created_ts.clone(),
+                    odcs_metadata: table_data.odcs_metadata.clone(),
                 }
             })
             .collect();
@@ -1613,7 +1634,6 @@ mod wasm {
     #[wasm_bindgen]
     pub fn create_workspace(name: &str, owner_id: &str) -> Result<String, JsValue> {
         use crate::models::workspace::Workspace;
-        use chrono::Utc;
         use uuid::Uuid;
 
         let owner_uuid =

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -194,6 +194,14 @@ pub struct SystemReference {
     /// Optional description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Optional array of table UUIDs that belong to this system.
+    /// When present, provides explicit table-to-system mapping without requiring parsing of individual ODCS files.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub table_ids: Vec<Uuid>,
+    /// Optional array of compute asset (CADS) UUIDs that belong to this system.
+    /// When present, provides explicit asset-to-system mapping.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub asset_ids: Vec<Uuid>,
 }
 
 /// Workspace - Top-level container for domains, assets, and relationships
@@ -340,6 +348,8 @@ impl Workspace {
                 id: system_id,
                 name: system_name,
                 description,
+                table_ids: Vec::new(),
+                asset_ids: Vec::new(),
             });
             self.last_modified_at = Utc::now();
             return true;


### PR DESCRIPTION
## Summary

This PR implements both GitHub issues #34 and #35:

### Issue #35 - `parse_odcs_yaml` doesn't return root-level `id` field

**Problem:** The ODCS `id` field was correctly extracted by `extract_table_uuid()` but was lost during `TableData` construction, causing tables to appear unlinked from parent systems.

**Solution:** 
- Added `id` field to `TableData` struct
- Expanded `TableData` to include ALL ODCS v3.1.0 contract-level fields:
  - `apiVersion`, `version`, `status`, `kind`, `domain`, `dataProduct`, `tenant`
  - `description`, `servers`, `team`, `support`, `roles`
  - `slaProperties`, `quality`, `price`, `tags`
  - `customProperties`, `authoritativeDefinitions`, `contractCreatedTs`, `odcsMetadata`
- Updated ODCS and ODCL importers to extract all fields from source YAML
- Other importers (Avro, JSON Schema, Protobuf, SQL) use `..Default::default()` for ODCS-specific fields

### Issue #34 - Add `table_ids` and `asset_ids` to SystemReference

**Problem:** System-resource relationships were inferred through `customProperties.system_id`, requiring indirect lookups.

**Solution:**
- Added optional `table_ids` and `asset_ids` UUID arrays to `SystemReference` in:
  - `schemas/workspace-schema.json`
  - `src/models/workspace.rs`
- Updated `add_system_to_domain` method to initialize new fields

## Changes

- `src/import/mod.rs` - Expanded `TableData` struct with all ODCS fields
- `src/import/odcs.rs` - Extract all contract-level fields during import
- `src/import/odcl.rs` - Extract all contract-level fields during import
- `src/import/avro.rs`, `json_schema.rs`, `protobuf.rs`, `sql.rs` - Use Default for new fields
- `src/models/workspace.rs` - Add `table_ids` and `asset_ids` to `SystemReference`
- `schemas/workspace-schema.json` - Add new fields to schema
- `src/lib.rs` - Remove unused import, update WASM bindings
- `Cargo.toml` - Bump version to 1.13.5
- `CHANGELOG.md` - Document changes

## Testing

- All 122 unit tests pass
- All integration tests pass
- Clippy reports no warnings
- WASM package rebuilt successfully

Closes #34, Closes #35