### PR TITLE
fix(ci): add id-token permission for npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,3 +181,4 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+      id-token: write # Required for npm provenance


### PR DESCRIPTION
## Summary

Fixes the workflow validation error:
```
The nested job 'publish-npm' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

## Changes

- Add `id-token: write` permission to the `release` job in `publish.yml`
- This allows the nested `publish-npm` job in `release-cli.yml` to use OIDC for npm provenance attestation

## Why

When `release-cli.yml` is called from `publish.yml`, permissions are inherited and restricted. The nested job requesting `id-token: write` requires the caller to also have that permission.