### PR TITLE
feat(serde): add dual-case JSON field name support for WASM deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.3] - 2026-01-11
+
+### Added
+
+- **feat(serde)**: Dual-case JSON field name support for WASM deserialization
+  - All struct fields with `#[serde(rename_all = "camelCase")]` now accept both camelCase and snake_case during deserialization
+  - Added `#[serde(alias = "snake_case")]` attributes to all multi-word field names
+  - Serialization output remains camelCase for consistency
+  - Updated structs: `Relationship`, `ForeignKeyDetails`, `ETLJobMetadata`, `VisualMetadata`, `Column`, `ForeignKey`, `PropertyRelationship`, `LogicalTypeOptions`, `AuthoritativeDefinition`, `Workspace`, `AssetReference`, `DomainReference`, `SystemReference`, `Table`, `SlaProperty`, `ContactDetails`, `CADSAsset`, `CADSDescription`, `CADSPricing`, `CADSRisk`, `CADSValidationProfile`, `CADSValidationProfileAppliesTo`, `KnowledgeArticle`, `KnowledgeIndex`, `KnowledgeIndexEntry`, `RelatedArticle`, `Decision`, `DecisionIndex`, `AssetLink`, `ComplianceAssessment`
+  - Enables UI flexibility when passing JSON with either naming convention
+
 ## [1.14.2] - 2026-01-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "data-modelling-sdk"
-version = "1.14.2"
+version = "1.14.3"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"
 description = "Shared SDK for model operations across platforms (API, WASM, Native)"
-repository = "https://github.com/pixie79/data-modelling-sdk"
+repository = "https://github.com/OffeneDatenmodellierung/data-modelling-sdk"
 
 [lib]
 name = "data_modelling_sdk"

--- a/src/models/cads.rs
+++ b/src/models/cads.rs
@@ -50,7 +50,7 @@ pub struct CADSDescription {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limitations: Option<String>,
     /// External links and references
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "external_links")]
     pub external_links: Option<Vec<CADSExternalLink>>,
 }
 
@@ -136,10 +136,10 @@ pub struct CADSPricing {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<String>,
     /// Unit cost
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "unit_cost")]
     pub unit_cost: Option<f64>,
     /// Billing unit
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "billing_unit")]
     pub billing_unit: Option<String>,
     /// Additional notes
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -235,13 +235,13 @@ pub struct CADSRisk {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub classification: Option<CADSRiskClassification>,
     /// Impact areas
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "impact_areas")]
     pub impact_areas: Option<Vec<CADSImpactArea>>,
     /// Intended use
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "intended_use")]
     pub intended_use: Option<String>,
     /// Out of scope use
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "out_of_scope_use")]
     pub out_of_scope_use: Option<String>,
     /// Risk assessment
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -304,7 +304,7 @@ pub struct CADSValidationProfileAppliesTo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     /// Risk classification
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "risk_classification")]
     pub risk_classification: Option<String>,
 }
 
@@ -315,9 +315,10 @@ pub struct CADSValidationProfile {
     /// Profile name
     pub name: String,
     /// Applies to criteria
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "applies_to")]
     pub applies_to: Option<CADSValidationProfileAppliesTo>,
     /// Required checks
+    #[serde(alias = "required_checks")]
     pub required_checks: Vec<String>,
 }
 
@@ -400,6 +401,7 @@ pub struct CADSOpenAPISpec {
 #[serde(rename_all = "camelCase")]
 pub struct CADSAsset {
     /// API version
+    #[serde(alias = "api_version")]
     pub api_version: String,
     /// Asset kind
     pub kind: CADSKind,
@@ -439,25 +441,25 @@ pub struct CADSAsset {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compliance: Option<CADSCompliance>,
     /// Validation profiles
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "validation_profiles")]
     pub validation_profiles: Option<Vec<CADSValidationProfile>>,
     /// BPMN models
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "bpmn_models")]
     pub bpmn_models: Option<Vec<CADSBPMNModel>>,
     /// DMN models
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "dmn_models")]
     pub dmn_models: Option<Vec<CADSDMNModel>>,
     /// OpenAPI specifications
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "openapi_specs")]
     pub openapi_specs: Option<Vec<CADSOpenAPISpec>>,
     /// Custom properties
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "custom_properties")]
     pub custom_properties: Option<HashMap<String, serde_json::Value>>,
     /// Creation timestamp
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "created_at")]
     pub created_at: Option<DateTime<Utc>>,
     /// Last update timestamp
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "updated_at")]
     pub updated_at: Option<DateTime<Utc>>,
 }
 

--- a/src/models/column.rs
+++ b/src/models/column.rs
@@ -5,18 +5,22 @@ use std::collections::HashMap;
 
 /// Foreign key reference to another table's column
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct ForeignKey {
     /// Target table ID (UUID as string)
+    #[serde(alias = "table_id")]
     pub table_id: String,
     /// Column name in the target table
+    #[serde(alias = "column_name")]
     pub column_name: String,
 }
 
 /// ODCS v3.1.0 Relationship at property level
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct PropertyRelationship {
     /// Relationship type (e.g., "foreignKey", "parent", "child")
-    #[serde(rename = "type")]
+    #[serde(rename = "type", alias = "relationship_type")]
     pub relationship_type: String,
     /// Target reference (e.g., "definitions/order_id", "schema/id/properties/id")
     pub to: String,
@@ -27,10 +31,10 @@ pub struct PropertyRelationship {
 #[serde(rename_all = "camelCase")]
 pub struct LogicalTypeOptions {
     /// Minimum length for strings
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "min_length")]
     pub min_length: Option<i64>,
     /// Maximum length for strings
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "max_length")]
     pub max_length: Option<i64>,
     /// Regex pattern for strings
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -45,10 +49,10 @@ pub struct LogicalTypeOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum: Option<serde_json::Value>,
     /// Exclusive minimum for numbers
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "exclusive_minimum")]
     pub exclusive_minimum: Option<serde_json::Value>,
     /// Exclusive maximum for numbers
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "exclusive_maximum")]
     pub exclusive_maximum: Option<serde_json::Value>,
     /// Precision for decimals
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -75,9 +79,10 @@ impl LogicalTypeOptions {
 
 /// Authoritative definition reference (ODCS v3.1.0)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct AuthoritativeDefinition {
     /// Type of the reference (e.g., "businessDefinition", "transformationImplementation")
-    #[serde(rename = "type")]
+    #[serde(rename = "type", alias = "definition_type")]
     pub definition_type: String,
     /// URL to the authoritative definition
     pub url: String,
@@ -105,7 +110,7 @@ pub struct Column {
     /// Column name (ODCS: name)
     pub name: String,
     /// Business name for the column (ODCS: businessName)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "business_name")]
     pub business_name: Option<String>,
     /// Column description/documentation (ODCS: description)
     #[serde(default)]
@@ -113,24 +118,30 @@ pub struct Column {
 
     // === Type Information ===
     /// Logical data type (ODCS: logicalType - e.g., "string", "integer", "number")
-    #[serde(rename = "dataType")]
+    #[serde(rename = "dataType", alias = "data_type")]
     pub data_type: String,
     /// Physical database type (ODCS: physicalType - e.g., "VARCHAR(100)", "BIGINT")
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "physical_type")]
     pub physical_type: Option<String>,
     /// Physical name in the data source (ODCS: physicalName)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "physical_name")]
     pub physical_name: Option<String>,
     /// Additional type options (ODCS: logicalTypeOptions)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "logical_type_options"
+    )]
     pub logical_type_options: Option<LogicalTypeOptions>,
 
     // === Key Constraints ===
     /// Whether this column is part of the primary key (ODCS: primaryKey)
-    #[serde(default)]
+    #[serde(default, alias = "primary_key")]
     pub primary_key: bool,
     /// Position in composite primary key, 1-based (ODCS: primaryKeyPosition)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "primary_key_position"
+    )]
     pub primary_key_position: Option<i32>,
     /// Whether the column contains unique values (ODCS: unique)
     #[serde(default)]
@@ -144,7 +155,10 @@ pub struct Column {
     #[serde(default)]
     pub partitioned: bool,
     /// Position in partition key, 1-based (ODCS: partitionKeyPosition)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "partition_key_position"
+    )]
     pub partition_key_position: Option<i32>,
     /// Whether the column is used for clustering
     #[serde(default)]
@@ -155,21 +169,28 @@ pub struct Column {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub classification: Option<String>,
     /// Whether this is a critical data element (ODCS: criticalDataElement)
-    #[serde(default)]
+    #[serde(default, alias = "critical_data_element")]
     pub critical_data_element: bool,
     /// Name of the encrypted version of this column (ODCS: encryptedName)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "encrypted_name")]
     pub encrypted_name: Option<String>,
 
     // === Transformation Metadata ===
     /// Source objects used in transformation (ODCS: transformSourceObjects)
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "transform_source_objects"
+    )]
     pub transform_source_objects: Vec<String>,
     /// Transformation logic/expression (ODCS: transformLogic)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "transform_logic")]
     pub transform_logic: Option<String>,
     /// Human-readable transformation description (ODCS: transformDescription)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "transform_description"
+    )]
     pub transform_description: Option<String>,
 
     // === Examples & Documentation ===
@@ -177,7 +198,7 @@ pub struct Column {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub examples: Vec<serde_json::Value>,
     /// Default value for the column
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "default_value")]
     pub default_value: Option<serde_json::Value>,
 
     // === Relationships & References ===
@@ -185,7 +206,11 @@ pub struct Column {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub relationships: Vec<PropertyRelationship>,
     /// Authoritative definitions (ODCS: authoritativeDefinitions)
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "authoritative_definitions"
+    )]
     pub authoritative_definitions: Vec<AuthoritativeDefinition>,
 
     // === Quality & Validation ===
@@ -193,7 +218,7 @@ pub struct Column {
     #[serde(default)]
     pub quality: Vec<HashMap<String, serde_json::Value>>,
     /// Enum values if this column is an enumeration type
-    #[serde(default)]
+    #[serde(default, alias = "enum_values")]
     pub enum_values: Vec<String>,
 
     // === Tags & Custom Properties ===
@@ -201,18 +226,22 @@ pub struct Column {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
     /// Custom properties for format-specific metadata not covered by ODCS
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        alias = "custom_properties"
+    )]
     pub custom_properties: HashMap<String, serde_json::Value>,
 
     // === Legacy/Internal Fields ===
     /// Whether this column is a secondary/business key
-    #[serde(default)]
+    #[serde(default, alias = "secondary_key")]
     pub secondary_key: bool,
     /// Composite key name if this column is part of a composite key
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "composite_key")]
     pub composite_key: Option<String>,
     /// Foreign key reference (legacy - prefer relationships)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "foreign_key")]
     pub foreign_key: Option<ForeignKey>,
     /// Additional constraints (e.g., "CHECK", "UNIQUE")
     #[serde(default)]
@@ -221,10 +250,10 @@ pub struct Column {
     #[serde(default)]
     pub errors: Vec<HashMap<String, serde_json::Value>>,
     /// Display order for UI rendering
-    #[serde(default)]
+    #[serde(default, alias = "column_order")]
     pub column_order: i32,
     /// Nested data type for ARRAY<STRUCT> or MAP types
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "nested_data")]
     pub nested_data: Option<String>,
 }
 

--- a/src/models/decision.rs
+++ b/src/models/decision.rs
@@ -230,10 +230,13 @@ pub enum AssetRelationship {
 #[serde(rename_all = "camelCase")]
 pub struct AssetLink {
     /// Type of asset (odcs, odps, cads, relationship)
+    #[serde(alias = "asset_type")]
     pub asset_type: String,
     /// UUID of the linked asset
+    #[serde(alias = "asset_id")]
     pub asset_id: Uuid,
     /// Name of the linked asset
+    #[serde(alias = "asset_name")]
     pub asset_name: String,
     /// Relationship between decision and asset
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -276,13 +279,13 @@ impl AssetLink {
 #[serde(rename_all = "camelCase")]
 pub struct ComplianceAssessment {
     /// Impact on regulatory requirements
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "regulatory_impact")]
     pub regulatory_impact: Option<String>,
     /// Privacy impact assessment
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "privacy_assessment")]
     pub privacy_assessment: Option<String>,
     /// Security impact assessment
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "security_assessment")]
     pub security_assessment: Option<String>,
     /// Applicable compliance frameworks (GDPR, SOC2, HIPAA, etc.)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -361,17 +364,17 @@ pub struct Decision {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
     /// Domain UUID reference (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "domain_id")]
     pub domain_id: Option<Uuid>,
     /// Workspace UUID reference (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "workspace_id")]
     pub workspace_id: Option<Uuid>,
 
     // MADR template fields
     /// Date the decision was made
     pub date: DateTime<Utc>,
     /// When the decision was accepted/finalized
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "decided_at")]
     pub decided_at: Option<DateTime<Utc>>,
     /// Authors of the decision record
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -401,19 +404,31 @@ pub struct Decision {
 
     // Linking
     /// Assets affected by this decision
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "linked_assets"
+    )]
     pub linked_assets: Vec<AssetLink>,
     /// ID of the decision this supersedes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supersedes: Option<Uuid>,
     /// ID of the decision that superseded this
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "superseded_by")]
     pub superseded_by: Option<Uuid>,
     /// IDs of related decisions
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "related_decisions"
+    )]
     pub related_decisions: Vec<Uuid>,
     /// IDs of related knowledge articles
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "related_knowledge"
+    )]
     pub related_knowledge: Vec<Uuid>,
 
     // Compliance (from feature request)
@@ -423,10 +438,10 @@ pub struct Decision {
 
     // Confirmation tracking (from feature request)
     /// Date the decision was confirmed/reviewed
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "confirmation_date")]
     pub confirmation_date: Option<DateTime<Utc>>,
     /// Notes from confirmation review
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "confirmation_notes")]
     pub confirmation_notes: Option<String>,
 
     // Standard metadata
@@ -438,8 +453,10 @@ pub struct Decision {
     pub notes: Option<String>,
 
     /// Creation timestamp
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
     /// Last modification timestamp
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 

--- a/src/models/knowledge.rs
+++ b/src/models/knowledge.rs
@@ -176,10 +176,13 @@ impl std::fmt::Display for ArticleRelationship {
 
 /// Reference to a related article
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct RelatedArticle {
     /// UUID of the related article
+    #[serde(alias = "article_id")]
     pub article_id: Uuid,
     /// Article number (e.g., "KB-0001")
+    #[serde(alias = "article_number")]
     pub article_number: String,
     /// Article title
     pub title: String,
@@ -276,6 +279,7 @@ pub struct KnowledgeArticle {
     /// Article title
     pub title: String,
     /// Type of article
+    #[serde(alias = "article_type")]
     pub article_type: KnowledgeType,
     /// Publication status
     pub status: KnowledgeStatus,
@@ -283,10 +287,10 @@ pub struct KnowledgeArticle {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
     /// Domain UUID reference (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "domain_id")]
     pub domain_id: Option<Uuid>,
     /// Workspace UUID reference (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "workspace_id")]
     pub workspace_id: Option<Uuid>,
 
     // Content
@@ -303,19 +307,19 @@ pub struct KnowledgeArticle {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub reviewers: Vec<String>,
     /// Date of last review (legacy field name)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "last_reviewed")]
     pub last_reviewed: Option<DateTime<Utc>>,
     /// Last review timestamp (camelCase alias)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "reviewed_at")]
     pub reviewed_at: Option<DateTime<Utc>>,
     /// When the article was published
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "published_at")]
     pub published_at: Option<DateTime<Utc>>,
     /// When the article was archived
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "archived_at")]
     pub archived_at: Option<DateTime<Utc>>,
     /// How often the article should be reviewed
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "review_frequency")]
     pub review_frequency: Option<ReviewFrequency>,
 
     // Classification
@@ -323,27 +327,43 @@ pub struct KnowledgeArticle {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub audience: Vec<String>,
     /// Required skill level
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "skill_level")]
     pub skill_level: Option<SkillLevel>,
 
     // Linking
     /// Assets referenced by this article
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "linked_assets"
+    )]
     pub linked_assets: Vec<AssetLink>,
     /// UUIDs of related decisions (legacy field)
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "linked_decisions"
+    )]
     pub linked_decisions: Vec<Uuid>,
     /// IDs of related decision records
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "related_decisions"
+    )]
     pub related_decisions: Vec<Uuid>,
     /// Related articles (detailed info)
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "related_articles"
+    )]
     pub related_articles: Vec<RelatedArticle>,
     /// IDs of prerequisite articles (must read first)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub prerequisites: Vec<Uuid>,
     /// IDs of 'See Also' articles for further reading
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty", alias = "see_also")]
     pub see_also: Vec<Uuid>,
 
     // Standard metadata
@@ -355,8 +375,10 @@ pub struct KnowledgeArticle {
     pub notes: Option<String>,
 
     /// Creation timestamp
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
     /// Last modification timestamp
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 
@@ -645,6 +667,7 @@ pub struct KnowledgeIndexEntry {
     /// Article title
     pub title: String,
     /// Article type
+    #[serde(alias = "article_type")]
     pub article_type: KnowledgeType,
     /// Article status
     pub status: KnowledgeStatus,
@@ -674,17 +697,19 @@ impl From<&KnowledgeArticle> for KnowledgeIndexEntry {
 #[serde(rename_all = "camelCase")]
 pub struct KnowledgeIndex {
     /// Schema version
+    #[serde(alias = "schema_version")]
     pub schema_version: String,
     /// Last update timestamp
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "last_updated")]
     pub last_updated: Option<DateTime<Utc>>,
     /// List of articles
     #[serde(default)]
     pub articles: Vec<KnowledgeIndexEntry>,
     /// Next available article number (for sequential numbering)
+    #[serde(alias = "next_number")]
     pub next_number: u64,
     /// Whether to use timestamp-based numbering (YYMMDDHHmm format)
-    #[serde(default)]
+    #[serde(default, alias = "use_timestamp_numbering")]
     pub use_timestamp_numbering: bool,
 }
 

--- a/src/models/relationship.rs
+++ b/src/models/relationship.rs
@@ -13,8 +13,10 @@ use uuid::Uuid;
 #[serde(rename_all = "camelCase")]
 pub struct ForeignKeyDetails {
     /// Column name in the source table
+    #[serde(alias = "source_column")]
     pub source_column: String,
     /// Column name in the target table
+    #[serde(alias = "target_column")]
     pub target_column: String,
 }
 
@@ -23,6 +25,7 @@ pub struct ForeignKeyDetails {
 #[serde(rename_all = "camelCase")]
 pub struct ETLJobMetadata {
     /// Name of the ETL job that creates this relationship
+    #[serde(alias = "job_name")]
     pub job_name: String,
     /// Optional notes about the ETL job
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -46,16 +49,22 @@ pub struct ConnectionPoint {
 #[serde(rename_all = "camelCase")]
 pub struct VisualMetadata {
     /// Connection point identifier on source table
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "source_connection_point"
+    )]
     pub source_connection_point: Option<String>,
     /// Connection point identifier on target table
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "target_connection_point"
+    )]
     pub target_connection_point: Option<String>,
     /// Waypoints for routing the relationship line
-    #[serde(default)]
+    #[serde(default, alias = "routing_waypoints")]
     pub routing_waypoints: Vec<ConnectionPoint>,
     /// Position for the relationship label
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "label_position")]
     pub label_position: Option<ConnectionPoint>,
 }
 
@@ -145,35 +154,37 @@ pub struct Relationship {
     /// Unique identifier for the relationship (UUIDv4)
     pub id: Uuid,
     /// ID of the source table
+    #[serde(alias = "source_table_id")]
     pub source_table_id: Uuid,
     /// ID of the target table
+    #[serde(alias = "target_table_id")]
     pub target_table_id: Uuid,
     /// Legacy cardinality (OneToOne, OneToMany, ManyToMany) - for backward compatibility
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cardinality: Option<Cardinality>,
     /// Whether the source side is optional (nullable foreign key) - legacy field
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "source_optional")]
     pub source_optional: Option<bool>,
     /// Whether the target side is optional - legacy field
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "target_optional")]
     pub target_optional: Option<bool>,
     /// Crow's feet cardinality at the source end (zeroOrOne, exactlyOne, zeroOrMany, oneOrMany)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "source_cardinality")]
     pub source_cardinality: Option<EndpointCardinality>,
     /// Crow's feet cardinality at the target end (zeroOrOne, exactlyOne, zeroOrMany, oneOrMany)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "target_cardinality")]
     pub target_cardinality: Option<EndpointCardinality>,
     /// Direction of data flow (sourceToTarget, targetToSource, bidirectional)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "flow_direction")]
     pub flow_direction: Option<FlowDirection>,
     /// Foreign key column mapping details
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "foreign_key_details")]
     pub foreign_key_details: Option<ForeignKeyDetails>,
     /// ETL job metadata for data flow relationships
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "etl_job_metadata")]
     pub etl_job_metadata: Option<ETLJobMetadata>,
     /// Type of relationship (ForeignKey, DataFlow, Dependency, ETL)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "relationship_type")]
     pub relationship_type: Option<RelationshipType>,
     /// Optional notes about the relationship
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -185,29 +196,31 @@ pub struct Relationship {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sla: Option<Vec<SlaProperty>>,
     /// Contact details for responsible parties
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "contact_details")]
     pub contact_details: Option<ContactDetails>,
     /// Infrastructure type (hosting platform, service, or tool) for Data Flow relationships
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "infrastructure_type")]
     pub infrastructure_type: Option<InfrastructureType>,
     /// Visual metadata for canvas rendering
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "visual_metadata")]
     pub visual_metadata: Option<VisualMetadata>,
     /// Draw.io edge ID for diagram integration
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "drawio_edge_id")]
     pub drawio_edge_id: Option<String>,
     /// Color for the relationship line in the UI (hex color code or named color)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// Edge attachment point on the source node
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "source_handle")]
     pub source_handle: Option<ConnectionHandle>,
     /// Edge attachment point on the target node
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "target_handle")]
     pub target_handle: Option<ConnectionHandle>,
     /// Creation timestamp
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
     /// Last update timestamp
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 

--- a/src/models/table.rs
+++ b/src/models/table.rs
@@ -72,6 +72,7 @@ pub struct Position {
 /// Represents a single SLA property for Data Flow nodes and relationships.
 /// Uses a lightweight format inspired by ODCS servicelevels but separate from ODCS.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct SlaProperty {
     /// SLA attribute name (e.g., "latency", "availability", "throughput")
     pub property: String,
@@ -100,6 +101,7 @@ pub struct SlaProperty {
 ///
 /// Structured contact information for operational and governance purposes.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct ContactDetails {
     /// Email address
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -170,6 +172,7 @@ pub struct ContactDetails {
 /// table.notes = Some("User interaction events from web application".to_string());
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Table {
     /// Unique identifier for the table (UUIDv4)
     pub id: Uuid,
@@ -178,31 +181,34 @@ pub struct Table {
     /// List of columns in the table
     pub columns: Vec<Column>,
     /// Database type (PostgreSQL, MySQL, etc.) if applicable
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "database_type")]
     pub database_type: Option<DatabaseType>,
     /// Catalog name (database name in some systems)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "catalog_name")]
     pub catalog_name: Option<String>,
     /// Schema name (namespace within catalog)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "schema_name")]
     pub schema_name: Option<String>,
     /// Medallion architecture layers (Bronze, Silver, Gold)
-    #[serde(default)]
+    #[serde(default, alias = "medallion_layers")]
     pub medallion_layers: Vec<MedallionLayer>,
     /// Slowly Changing Dimension pattern (Type 1, Type 2, etc.)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "scd_pattern")]
     pub scd_pattern: Option<SCDPattern>,
     /// Data Vault classification (Hub, Link, Satellite)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "data_vault_classification"
+    )]
     pub data_vault_classification: Option<DataVaultClassification>,
     /// Modeling level (Conceptual, Logical, Physical)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "modeling_level")]
     pub modeling_level: Option<ModelingLevel>,
     /// Tags for categorization and filtering (supports Simple, Pair, and List formats)
     #[serde(default, deserialize_with = "deserialize_tags")]
     pub tags: Vec<Tag>,
     /// ODCL/ODCS metadata (legacy format support)
-    #[serde(default)]
+    #[serde(default, alias = "odcl_metadata")]
     pub odcl_metadata: HashMap<String, serde_json::Value>,
     /// Owner information (person, team, or organization name) for Data Flow nodes
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -211,10 +217,10 @@ pub struct Table {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sla: Option<Vec<SlaProperty>>,
     /// Contact details for responsible parties
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "contact_details")]
     pub contact_details: Option<ContactDetails>,
     /// Infrastructure type (hosting platform, service, or tool) for Data Flow nodes
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "infrastructure_type")]
     pub infrastructure_type: Option<InfrastructureType>,
     /// Additional notes and context for Data Flow nodes
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -223,10 +229,10 @@ pub struct Table {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<Position>,
     /// Path to YAML file if loaded from file system
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "yaml_file_path")]
     pub yaml_file_path: Option<String>,
     /// Draw.io cell ID for diagram integration
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "drawio_cell_id")]
     pub drawio_cell_id: Option<String>,
     /// Quality rules and checks
     #[serde(default)]
@@ -235,8 +241,10 @@ pub struct Table {
     #[serde(default)]
     pub errors: Vec<HashMap<String, serde_json::Value>>,
     /// Creation timestamp
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
     /// Last update timestamp
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -37,9 +37,10 @@ pub struct AssetReference {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<String>,
     /// Asset type (odcs, odps, cads)
+    #[serde(alias = "asset_type")]
     pub asset_type: AssetType,
     /// File path relative to workspace (generated from naming convention)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "file_path")]
     pub file_path: Option<String>,
 }
 
@@ -188,7 +189,11 @@ pub struct DomainReference {
     pub systems: Vec<SystemReference>,
     /// View positions for different view modes (operational, analytical, process, systems)
     /// Key: view mode name, Value: Map of entity ID to position
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        alias = "view_positions"
+    )]
     pub view_positions: HashMap<String, HashMap<String, ViewPosition>>,
 }
 
@@ -205,11 +210,11 @@ pub struct SystemReference {
     pub description: Option<String>,
     /// Optional array of table UUIDs that belong to this system.
     /// When present, provides explicit table-to-system mapping without requiring parsing of individual ODCS files.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty", alias = "table_ids")]
     pub table_ids: Vec<Uuid>,
     /// Optional array of compute asset (CADS) UUIDs that belong to this system.
     /// When present, provides explicit asset-to-system mapping.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty", alias = "asset_ids")]
     pub asset_ids: Vec<Uuid>,
 }
 
@@ -225,10 +230,13 @@ pub struct Workspace {
     /// Workspace name (used in file naming)
     pub name: String,
     /// Owner/creator user identifier
+    #[serde(alias = "owner_id")]
     pub owner_id: Uuid,
     /// Creation timestamp
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
     /// Last modification timestamp
+    #[serde(alias = "last_modified_at")]
     pub last_modified_at: DateTime<Utc>,
     /// Domain references with their systems
     #[serde(default)]


### PR DESCRIPTION
## Summary

This PR adds support for both camelCase and snake_case JSON field names during WASM deserialization, enabling UI flexibility when passing JSON with either naming convention.

## Changes

- Added `#[serde(alias = "snake_case")]` attributes to all multi-word camelCase struct fields
- Serialization output remains camelCase for consistency
- Updated structs across 7 files:
  - `relationship.rs`: ForeignKeyDetails, ETLJobMetadata, VisualMetadata, Relationship
  - `column.rs`: ForeignKey, PropertyRelationship, LogicalTypeOptions, AuthoritativeDefinition, Column
  - `workspace.rs`: AssetReference, DomainReference, SystemReference, Workspace
  - `table.rs`: SlaProperty, ContactDetails, Table
  - `cads.rs`: CADSDescription, CADSPricing, CADSRisk, CADSValidationProfileAppliesTo, CADSValidationProfile, CADSAsset
  - `knowledge.rs`: RelatedArticle, KnowledgeArticle, KnowledgeIndexEntry, KnowledgeIndex
  - `decision.rs`: AssetLink, ComplianceAssessment, Decision, DecisionIndex

## Example

Both of these JSON inputs now work:

```json
// camelCase (original)
{ "domainId": "...", "workspaceId": "..." }

// snake_case (now also accepted)
{ "domain_id": "...", "workspace_id": "..." }
```

## Version

Bumped to v1.14.3