### PR TITLE
ci: restructure workflows with version-check and proper publish order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,76 +14,16 @@ permissions:
   pull-requests: read
 
 jobs:
-  # Version consistency check - runs first to fail fast on version mismatches
+  # Version consistency check - runs first
   version-check:
-    name: Version Consistency Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Check version consistency across all files
-        run: |
-          echo "Checking version consistency across all Cargo.toml files, CHANGELOG.md, and package.json..."
-
-          # Extract versions from all locations
-          ROOT_VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          CORE_VERSION=$(grep -A 10 '^\[package\]' crates/core/Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          ODM_VERSION=$(grep -A 10 '^\[package\]' crates/odm/Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          WASM_VERSION=$(grep -A 10 '^\[package\]' crates/wasm/Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          PKG_VERSION=$(grep '"version"' pkg/package.json | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')
-          CHANGELOG_VERSION=$(grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
-
-          echo "Versions found:"
-          echo "  Root Cargo.toml:        $ROOT_VERSION"
-          echo "  crates/core/Cargo.toml: $CORE_VERSION"
-          echo "  crates/odm/Cargo.toml:  $ODM_VERSION"
-          echo "  crates/wasm/Cargo.toml: $WASM_VERSION"
-          echo "  pkg/package.json:       $PKG_VERSION"
-          echo "  CHANGELOG.md:           $CHANGELOG_VERSION"
-
-          # Check all versions match
-          ERRORS=0
-
-          if [ "$ROOT_VERSION" != "$CORE_VERSION" ]; then
-            echo "❌ ERROR: Root Cargo.toml ($ROOT_VERSION) != crates/core/Cargo.toml ($CORE_VERSION)"
-            ERRORS=$((ERRORS + 1))
-          fi
-
-          if [ "$ROOT_VERSION" != "$ODM_VERSION" ]; then
-            echo "❌ ERROR: Root Cargo.toml ($ROOT_VERSION) != crates/odm/Cargo.toml ($ODM_VERSION)"
-            ERRORS=$((ERRORS + 1))
-          fi
-
-          if [ "$ROOT_VERSION" != "$WASM_VERSION" ]; then
-            echo "❌ ERROR: Root Cargo.toml ($ROOT_VERSION) != crates/wasm/Cargo.toml ($WASM_VERSION)"
-            ERRORS=$((ERRORS + 1))
-          fi
-
-          if [ "$ROOT_VERSION" != "$PKG_VERSION" ]; then
-            echo "❌ ERROR: Root Cargo.toml ($ROOT_VERSION) != pkg/package.json ($PKG_VERSION)"
-            ERRORS=$((ERRORS + 1))
-          fi
-
-          if [ "$ROOT_VERSION" != "$CHANGELOG_VERSION" ]; then
-            echo "❌ ERROR: Root Cargo.toml ($ROOT_VERSION) != CHANGELOG.md ($CHANGELOG_VERSION)"
-            ERRORS=$((ERRORS + 1))
-          fi
-
-          if [ $ERRORS -gt 0 ]; then
-            echo ""
-            echo "Version consistency check failed with $ERRORS error(s)"
-            echo "All version files must have the same version number."
-            exit 1
-          fi
-
-          echo ""
-          echo "✅ All versions are consistent: $ROOT_VERSION"
+    name: Version Check
+    uses: ./.github/workflows/version-check.yml
 
   # Linting and formatting check
   lint:
     name: Lint and Format Check
+    needs: version-check
     runs-on: ubuntu-latest
-    needs: [version-check]
     steps:
       - uses: actions/checkout@v4
 
@@ -131,8 +71,8 @@ jobs:
   # Core tests - runs without database features (fast)
   test:
     name: Test
+    needs: version-check
     runs-on: ubuntu-latest
-    needs: [version-check]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,180 +5,138 @@ on:
   push:
     branches: [main] # Trigger on merge to main
 
-env:
-  CARGO_TERM_COLOR: always
-
 permissions:
   contents: write
   issues: write
+  id-token: write # Required for npm provenance
 
 jobs:
-  publish:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required for git tag operations and CHANGELOG verification
-          token: ${{ secrets.GITHUB_TOKEN }}
+  # Step 1: Verify all versions are consistent
+  version-check:
+    name: Version Check
+    uses: ./.github/workflows/version-check.yml
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+  # Step 2: Publish to crates.io (core first, then SDK)
+  release-sdk:
+    name: Release SDK
+    needs: version-check
+    uses: ./.github/workflows/release-sdk.yml
+    with:
+      version: ${{ needs.version-check.outputs.version }}
+    secrets: inherit
 
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Get version from Cargo.toml
-        id: version
-        run: |
-          # Extract version from [package] section only, not from dependencies
-          # This ensures we get the package version (1.4.0) and not dependency versions (0.20, etc.)
-          VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version from Cargo.toml: $VERSION"
-
-      - name: Verify version matches CHANGELOG.md
-        run: |
-          CARGO_VERSION="${{ steps.version.outputs.version }}"
-
-          # Extract the latest version from CHANGELOG.md
-          # Look for pattern: ## [X.Y.Z] - YYYY-MM-DD
-          CHANGELOG_VERSION=$(grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
-
-          if [ -z "$CHANGELOG_VERSION" ]; then
-            echo "Error: Could not find version in CHANGELOG.md"
-            echo "Expected format: ## [X.Y.Z] - YYYY-MM-DD"
-            exit 1
-          fi
-
-          echo "Version in Cargo.toml: $CARGO_VERSION"
-          echo "Version in CHANGELOG.md: $CHANGELOG_VERSION"
-
-          if [ "$CARGO_VERSION" != "$CHANGELOG_VERSION" ]; then
-            echo "Error: Version mismatch!"
-            echo "Cargo.toml version ($CARGO_VERSION) does not match CHANGELOG.md version ($CHANGELOG_VERSION)"
-            exit 1
-          fi
-
-          echo "✓ Version verification passed"
-
-      - name: Check if tag already exists
-        id: check-tag
-        run: |
-          TAG_NAME="v${{ steps.version.outputs.version }}"
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Tag $TAG_NAME already exists"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Tag $TAG_NAME does not exist"
-          fi
-
-      - name: Create git tag
-        if: steps.check-tag.outputs.exists == 'false'
-        run: |
-          TAG_NAME="v${{ steps.version.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
-          git push origin "$TAG_NAME"
-          echo "Created and pushed tag: $TAG_NAME"
-
-      - name: Extract referenced issues from commits
-        id: extract-issues
-        run: |
-          # Get commits since last tag (or all commits if no tag exists)
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            COMMITS=$(git log --pretty=format:"%s %b" --no-merges)
-          else
-            COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"%s %b" --no-merges)
-          fi
-
-          # Extract issue numbers from commit messages
-          # Patterns: "closes #123", "fixes #456", "resolves #789", or just "#123"
-          ISSUES=$(echo "$COMMITS" | grep -oE '(closes|fixes|resolves|implements|addresses)?\s*#?[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || echo "")
-
-          if [ -z "$ISSUES" ]; then
-            echo "No referenced issues found in commits"
-            echo "issues=" >> $GITHUB_OUTPUT
-          else
-            echo "Found referenced issues: $ISSUES"
-            echo "issues=$ISSUES" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Close referenced issues
-        if: steps.extract-issues.outputs.issues != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          ISSUES="${{ steps.extract-issues.outputs.issues }}"
-
-          for issue in $ISSUES; do
-            echo "Checking issue #$issue..."
-
-            # Check if issue exists and is open
-            ISSUE_STATE=$(gh issue view $issue --repo ${{ github.repository }} --json state -q .state 2>/dev/null || echo "notfound")
-
-            if [ "$ISSUE_STATE" = "notfound" ]; then
-              echo "  Issue #$issue not found, skipping"
-              continue
-            elif [ "$ISSUE_STATE" = "closed" ]; then
-              echo "  Issue #$issue is already closed, skipping"
-              continue
-            elif [ "$ISSUE_STATE" = "open" ]; then
-              echo "  Closing issue #$issue..."
-              gh issue close $issue --repo ${{ github.repository }} --comment "Closed automatically as part of release v$VERSION. This issue was referenced in the release commits." || echo "  Failed to close issue #$issue"
-            fi
-          done
-
-      - name: Verify package contents
-        run: |
-          # List files that would be included in the package (doesn't create package)
-          cargo package --list
-
-      - name: Build crate package
-        run: |
-          # Create the package file (.crate)
-          cargo package
-
-      - name: Login to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          # Use cargo login with environment variable (recommended approach)
-          # This avoids the deprecated --token flag warning
-          echo "$CARGO_REGISTRY_TOKEN" | cargo login
-
-      - name: Verify publish readiness (dry-run)
-        run: |
-          # Use cargo publish --dry-run to verify everything is ready for publishing
-          # This checks metadata, dependencies, and registry compatibility
-          cargo publish --dry-run --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Publish to crates.io
-        run: cargo publish
-
-  release:
-    name: Release CLI and WASM
-    needs: publish
+  # Step 3: Build and release CLI binaries
+  release-cli:
+    name: Release CLI
+    needs: [version-check, release-sdk]
     uses: ./.github/workflows/release-cli.yml
     with:
-      version: ${{ needs.publish.outputs.version }}
+      version: ${{ needs.version-check.outputs.version }}
     secrets: inherit
-    permissions:
-      contents: write
-      id-token: write # Required for npm provenance
+
+  # Step 4: Build and release WASM + npm package
+  release-wasm:
+    name: Release WASM
+    needs: [version-check, release-sdk]
+    uses: ./.github/workflows/release-wasm.yml
+    with:
+      version: ${{ needs.version-check.outputs.version }}
+      publish_npm: true
+    secrets: inherit
+
+  # Step 5: Create GitHub Release with all artifacts
+  create-release:
+    name: Create GitHub Release
+    needs: [version-check, release-cli, release-wasm]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: "*"
+          merge-multiple: true
+
+      - name: Create checksums
+        shell: bash
+        run: |
+          cd artifacts
+          if command -v sha256sum >/dev/null 2>&1; then
+            find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) | while read file; do
+              sha256sum "$file" > "${file}.sha256"
+            done
+          elif command -v shasum >/dev/null 2>&1; then
+            find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) | while read file; do
+              shasum -a 256 "$file" | awk '{print $1}' > "${file}.sha256"
+            done
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.version-check.outputs.version }}
+          name: v${{ needs.version-check.outputs.version }}
+          body: |
+            ## Data Modelling SDK v${{ needs.version-check.outputs.version }}
+
+            ### CLI Downloads
+
+            The CLI includes embedded DuckDB database support for high-performance local queries.
+
+            **Linux (x86_64)**
+            - Binary: [odm-linux-x86_64.tar.gz](https://github.com/${{ github.repository }}/releases/download/v${{ needs.version-check.outputs.version }}/odm-linux-x86_64-v${{ needs.version-check.outputs.version }}.tar.gz)
+            - SHA256: See checksum files
+
+            **macOS (Intel)**
+            - Binary: [odm-macos-x86_64.tar.gz](https://github.com/${{ github.repository }}/releases/download/v${{ needs.version-check.outputs.version }}/odm-macos-x86_64-v${{ needs.version-check.outputs.version }}.tar.gz)
+            - SHA256: See checksum files
+
+            **macOS (Apple Silicon)**
+            - Binary: [odm-macos-arm64.tar.gz](https://github.com/${{ github.repository }}/releases/download/v${{ needs.version-check.outputs.version }}/odm-macos-arm64-v${{ needs.version-check.outputs.version }}.tar.gz)
+            - SHA256: See checksum files
+
+            **Windows (x86_64)**
+            - Binary: [odm-windows-x86_64.zip](https://github.com/${{ github.repository }}/releases/download/v${{ needs.version-check.outputs.version }}/odm-windows-x86_64-v${{ needs.version-check.outputs.version }}.zip)
+            - SHA256: See checksum files
+
+            ### WASM Package
+
+            **WebAssembly SDK** (for browser/web applications)
+            - Archive: [data-modelling-sdk-wasm-v${{ needs.version-check.outputs.version }}.tar.gz](https://github.com/${{ github.repository }}/releases/download/v${{ needs.version-check.outputs.version }}/data-modelling-sdk-wasm-v${{ needs.version-check.outputs.version }}.tar.gz)
+            - SHA256: See checksum file
+
+            ### Rust Crate
+
+            ```toml
+            [dependencies]
+            data-modelling-sdk = "${{ needs.version-check.outputs.version }}"
+            ```
+
+            ### npm Package
+
+            ```bash
+            npm install @offenedatenmodellierung/data-modelling-sdk@${{ needs.version-check.outputs.version }}
+            ```
+
+            ### CLI Installation
+
+            **Linux/macOS:**
+            ```bash
+            tar -xzf odm-*-v${{ needs.version-check.outputs.version }}.tar.gz
+            sudo mv odm /usr/local/bin/
+            ```
+
+            **Windows:**
+            ```powershell
+            Expand-Archive odm-windows-x86_64-v${{ needs.version-check.outputs.version }}.zip
+            # Add to PATH or use full path
+            ```
+
+            See [CLI.md](https://github.com/${{ github.repository }}/blob/main/CLI.md) for CLI usage instructions.
+
+          files: |
+            artifacts/**/*
+          draft: false
+          prerelease: false

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,4 +1,4 @@
-name: Release CLI and WASM
+name: Release CLI
 
 on:
   workflow_dispatch: # Allow manual triggering
@@ -8,11 +8,6 @@ on:
         description: "Version to release (without v prefix)"
         required: true
         type: string
-  push:
-    tags:
-      - "v*" # Trigger on version tags (e.g., v1.6.2)
-    branches:
-      - "release/*" # Trigger on release branches for dev releases
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,46 +18,12 @@ permissions:
   contents: write
 
 jobs:
-  verify-versions:
-    name: Verify Version Consistency
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Extract and verify versions
-        id: version
-        run: |
-          # Get version from Cargo.toml
-          CARGO_VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "Cargo.toml version: $CARGO_VERSION"
-
-          # Get version from CHANGELOG.md
-          CHANGELOG_VERSION=$(grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
-          echo "CHANGELOG.md version: $CHANGELOG_VERSION"
-
-          # Check for version match
-          if [ "$CARGO_VERSION" != "$CHANGELOG_VERSION" ]; then
-            echo "::error::Version mismatch! Cargo.toml ($CARGO_VERSION) != CHANGELOG.md ($CHANGELOG_VERSION)"
-            exit 1
-          fi
-
-          # If triggered by tag, verify tag matches
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            TAG_VERSION=${GITHUB_REF#refs/tags/v}
-            echo "Tag version: $TAG_VERSION"
-            if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
-              echo "::error::Tag version ($TAG_VERSION) does not match Cargo.toml ($CARGO_VERSION)"
-              exit 1
-            fi
-          fi
-
-          echo "version=$CARGO_VERSION" >> $GITHUB_OUTPUT
-          echo "✓ All versions consistent: $CARGO_VERSION"
+  version-check:
+    name: Version Check
+    uses: ./.github/workflows/version-check.yml
 
   build-cli:
-    needs: verify-versions
+    needs: version-check
     name: Build CLI
     runs-on: ${{ matrix.os }}
     strategy:
@@ -213,10 +174,14 @@ jobs:
         shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          VERIFIED_VERSION: ${{ needs.version-check.outputs.version }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
             # Version passed from workflow_call
             VERSION="$INPUT_VERSION"
+          elif [ -n "$VERIFIED_VERSION" ]; then
+            # Use version from version-check job
+            VERSION="$VERIFIED_VERSION"
           elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             # Tag release: use tag version
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -274,7 +239,6 @@ jobs:
         shell: bash
         run: |
           echo "Version: ${{ steps.version.outputs.version }}"
-          echo "Is Dev: ${{ steps.version.outputs.is_dev }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -282,269 +246,3 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: ${{ steps.prepare.outputs.archive_name }}
           retention-days: 30
-
-  build-wasm:
-    name: Build WASM SDK
-    needs: verify-versions
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-wasm-
-
-      - name: Build WASM with openapi features
-        run: |
-          cd crates/wasm
-          wasm-pack build --target web --out-dir ../../pkg --features openapi,odps-validation
-
-      - name: Get version
-        id: version
-        shell: bash
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            # Version passed from workflow_call
-            VERSION="$INPUT_VERSION"
-          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            # Tag release: use tag version
-            VERSION=${GITHUB_REF#refs/tags/v}
-          elif [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
-            # Release branch: use Cargo.toml version with dev postfix
-            BASE_VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-            VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
-          else
-            # Manual run: use Cargo.toml version with dev postfix
-            BASE_VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-            VERSION="${BASE_VERSION}-dev"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building WASM version: $VERSION"
-
-          # Determine if this is a production release (tag push)
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "is_release=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_release=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Update package.json version
-        run: |
-          cd pkg
-          # Update version in package.json to match Cargo.toml
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
-          # Update package name to scoped package for npm
-          sed -i 's/"name": "data-modelling-sdk"/"name": "@offenedatenmodellierung\/data-modelling-sdk"/' package.json
-          # Add repository info
-          cat package.json | jq '. + {
-            "repository": {
-              "type": "git",
-              "url": "git+https://github.com/OffeneDatenmodellierung/data-modelling-sdk.git"
-            },
-            "homepage": "https://github.com/OffeneDatenmodellierung/data-modelling-sdk#readme",
-            "bugs": {
-              "url": "https://github.com/OffeneDatenmodellierung/data-modelling-sdk/issues"
-            },
-            "keywords": ["wasm", "data-modelling", "odcs", "schema", "rust"]
-          }' > package.json.tmp && mv package.json.tmp package.json
-          echo "Updated package.json:"
-          cat package.json
-
-      - name: Create WASM archive
-        id: archive
-        shell: bash
-        run: |
-          ARCHIVE_NAME="data-modelling-sdk-wasm-v${{ steps.version.outputs.version }}.tar.gz"
-          tar -czf $ARCHIVE_NAME -C pkg .
-          echo "archive_name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: wasm-sdk
-          path: ${{ steps.archive.outputs.archive_name }}
-          retention-days: 30
-
-      - name: Upload npm package artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: npm-package
-          path: pkg/
-          retention-days: 30
-
-  create-release:
-    name: Create GitHub Release
-    needs: [build-cli, build-wasm]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get version
-        id: version
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            VERSION="$INPUT_VERSION"
-          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          pattern: "*"
-          merge-multiple: true
-
-      - name: Create checksums
-        shell: bash
-        run: |
-          cd artifacts
-          if command -v sha256sum >/dev/null 2>&1; then
-            find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) | while read file; do
-              sha256sum "$file" > "${file}.sha256"
-            done
-          elif command -v shasum >/dev/null 2>&1; then
-            find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) | while read file; do
-              shasum -a 256 "$file" | awk '{print $1}' > "${file}.sha256"
-            done
-          fi
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: v${{ steps.version.outputs.version }}
-          body: |
-            ## Data Modelling SDK v${{ steps.version.outputs.version }}
-
-            ### CLI Downloads
-
-            The CLI includes embedded DuckDB database support for high-performance local queries.
-
-            **Linux (x86_64)**
-            - Binary: [odm-linux-x86_64.tar.gz](https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/odm-linux-x86_64-v${{ steps.version.outputs.version }}.tar.gz)
-            - SHA256: See checksum files
-
-            **macOS (Intel)**
-            - Binary: [odm-macos-x86_64.tar.gz](https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/odm-macos-x86_64-v${{ steps.version.outputs.version }}.tar.gz)
-            - SHA256: See checksum files
-
-            **macOS (Apple Silicon)**
-            - Binary: [odm-macos-arm64.tar.gz](https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/odm-macos-arm64-v${{ steps.version.outputs.version }}.tar.gz)
-            - SHA256: See checksum files
-
-            **Windows (x86_64)**
-            - Binary: [odm-windows-x86_64.zip](https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/odm-windows-x86_64-v${{ steps.version.outputs.version }}.zip)
-            - SHA256: See checksum files
-
-            ### WASM Package
-
-            **WebAssembly SDK** (for browser/web applications)
-            - Archive: [data-modelling-sdk-wasm-v${{ steps.version.outputs.version }}.tar.gz](https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/data-modelling-sdk-wasm-v${{ steps.version.outputs.version }}.tar.gz)
-            - SHA256: See checksum file
-
-            ### CLI Installation
-
-            **Linux/macOS:**
-            ```bash
-            tar -xzf odm-*-v${{ steps.version.outputs.version }}.tar.gz
-            sudo mv odm /usr/local/bin/
-            ```
-
-            **Windows:**
-            ```powershell
-            Expand-Archive odm-windows-x86_64-v${{ steps.version.outputs.version }}.zip
-            # Add to PATH or use full path
-            ```
-
-            ### WASM Installation
-
-            **For Cloudflare Pages / Web Applications:**
-            ```bash
-            # Download and extract
-            curl -L -o wasm.tar.gz https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/data-modelling-sdk-wasm-v${{ steps.version.outputs.version }}.tar.gz
-            tar -xzf wasm.tar.gz
-            # Copy to your frontend/public/wasm/ directory
-            cp -r pkg/* frontend/public/wasm/
-            ```
-
-            ### Usage
-
-            See [CLI.md](https://github.com/${{ github.repository }}/blob/main/CLI.md) for CLI usage instructions.
-
-            ### npm Package
-
-            ```bash
-            npm install @offenedatenmodellierung/data-modelling-sdk
-            ```
-
-          files: |
-            artifacts/**/*
-          draft: false
-          prerelease: false
-
-  publish-npm:
-    name: Publish to npm
-    needs: [build-wasm, create-release]
-    runs-on: ubuntu-latest
-    # Publish to npm on tag releases OR when called from publish.yml with a version
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.version != ''
-    permissions:
-      contents: read
-      id-token: write # Required for OIDC authentication with npm (provenance)
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Download npm package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: npm-package
-          path: pkg/
-
-      - name: Verify package contents
-        run: |
-          echo "Package contents:"
-          ls -la pkg/
-          echo ""
-          echo "package.json:"
-          cat pkg/package.json
-
-      # Publish to npm registry
-      # Note: --provenance requires id-token:write permission and creates
-      # a verifiable link between the npm package and this GitHub repo.
-      # If provenance fails, remove the --provenance flag.
-      - name: Publish to npm
-        run: |
-          cd pkg
-          npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,0 +1,156 @@
+name: Release SDK to crates.io
+
+on:
+  workflow_dispatch: # Allow manual triggering
+  workflow_call: # Allow being called from publish.yml
+    inputs:
+      version:
+        description: "Version to release (without v prefix)"
+        required: false
+        type: string
+    outputs:
+      version:
+        description: "The published version"
+        value: ${{ jobs.publish.outputs.version }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  version-check:
+    name: Version Check
+    uses: ./.github/workflows/version-check.yml
+
+  publish:
+    name: Publish to crates.io
+    needs: version-check
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git tag operations
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Get version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          VERIFIED_VERSION: ${{ needs.version-check.outputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          elif [ -n "$VERIFIED_VERSION" ]; then
+            VERSION="$VERIFIED_VERSION"
+          else
+            VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check-tag
+        run: |
+          TAG_NAME="v${{ steps.version.outputs.version }}"
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag $TAG_NAME already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag $TAG_NAME does not exist"
+          fi
+
+      - name: Create git tag
+        if: steps.check-tag.outputs.exists == 'false'
+        run: |
+          TAG_NAME="v${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          git push origin "$TAG_NAME"
+          echo "Created and pushed tag: $TAG_NAME"
+
+      - name: Extract referenced issues from commits
+        id: extract-issues
+        run: |
+          # Get commits since last tag (or all commits if no tag exists)
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s %b" --no-merges)
+          else
+            COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"%s %b" --no-merges)
+          fi
+
+          # Extract issue numbers from commit messages
+          ISSUES=$(echo "$COMMITS" | grep -oE '(closes|fixes|resolves|implements|addresses)?\s*#?[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || echo "")
+
+          if [ -z "$ISSUES" ]; then
+            echo "No referenced issues found in commits"
+            echo "issues=" >> $GITHUB_OUTPUT
+          else
+            echo "Found referenced issues: $ISSUES"
+            echo "issues=$ISSUES" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Close referenced issues
+        if: steps.extract-issues.outputs.issues != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ISSUES="${{ steps.extract-issues.outputs.issues }}"
+
+          for issue in $ISSUES; do
+            echo "Checking issue #$issue..."
+            ISSUE_STATE=$(gh issue view $issue --repo ${{ github.repository }} --json state -q .state 2>/dev/null || echo "notfound")
+
+            if [ "$ISSUE_STATE" = "notfound" ]; then
+              echo "  Issue #$issue not found, skipping"
+              continue
+            elif [ "$ISSUE_STATE" = "closed" ]; then
+              echo "  Issue #$issue is already closed, skipping"
+              continue
+            elif [ "$ISSUE_STATE" = "open" ]; then
+              echo "  Closing issue #$issue..."
+              gh issue close $issue --repo ${{ github.repository }} --comment "Closed automatically as part of release v$VERSION." || echo "  Failed to close issue #$issue"
+            fi
+          done
+
+      - name: Login to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          echo "$CARGO_REGISTRY_TOKEN" | cargo login
+
+      # Publish crates in dependency order: core first, then root SDK
+      - name: Publish data-modelling-core to crates.io
+        run: |
+          cd crates/core
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          echo "Waiting for crates.io to index the package..."
+          sleep 30
+
+      - name: Publish data-modelling-sdk to crates.io
+        run: |
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,22 +1,22 @@
 name: Release WASM & npm
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Allow manual triggering
     inputs:
       version:
-        description: "Version to release (without v prefix, e.g., 1.14.0)"
-        required: true
+        description: "Version to release (without v prefix, e.g., 2.0.0). Leave empty to use Cargo.toml version."
+        required: false
         type: string
       publish_npm:
         description: "Publish to npm"
         required: true
         type: boolean
         default: true
-  workflow_call:
+  workflow_call: # Allow being called from publish.yml
     inputs:
       version:
         description: "Version to release (without v prefix)"
-        required: true
+        required: false
         type: string
       publish_npm:
         description: "Publish to npm"
@@ -32,8 +32,13 @@ permissions:
   id-token: write # Required for npm provenance
 
 jobs:
+  version-check:
+    name: Version Check
+    uses: ./.github/workflows/version-check.yml
+
   build-wasm:
     name: Build WASM SDK
+    needs: version-check
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -65,8 +70,17 @@ jobs:
 
       - name: Set version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          VERIFIED_VERSION: ${{ needs.version-check.outputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          elif [ -n "$VERIFIED_VERSION" ]; then
+            VERSION="$VERIFIED_VERSION"
+          else
+            VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building WASM version: $VERSION"
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,83 @@
+name: Version Check
+
+on:
+  workflow_dispatch: # Allow manual triggering
+  workflow_call: # Allow being called from other workflows
+    outputs:
+      version:
+        description: "The verified version"
+        value: ${{ jobs.verify-versions.outputs.version }}
+
+jobs:
+  verify-versions:
+    name: Verify Version Consistency
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract and verify versions
+        id: version
+        run: |
+          echo "Checking version consistency across all Cargo.toml files and CHANGELOG.md..."
+
+          # Get versions from all Cargo.toml files
+          ROOT_VERSION=$(grep -A 10 '^\[package\]' Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+          CORE_VERSION=$(grep -A 10 '^\[package\]' crates/core/Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+          ODM_VERSION=$(grep -A 10 '^\[package\]' crates/odm/Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+          WASM_VERSION=$(grep -A 10 '^\[package\]' crates/wasm/Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+          # Get version from CHANGELOG.md
+          CHANGELOG_VERSION=$(grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
+
+          echo "Versions found:"
+          echo "  Root Cargo.toml:        $ROOT_VERSION"
+          echo "  crates/core/Cargo.toml: $CORE_VERSION"
+          echo "  crates/odm/Cargo.toml:  $ODM_VERSION"
+          echo "  crates/wasm/Cargo.toml: $WASM_VERSION"
+          echo "  CHANGELOG.md:           $CHANGELOG_VERSION"
+
+          # Check for version mismatches
+          ERRORS=0
+
+          if [ "$ROOT_VERSION" != "$CORE_VERSION" ]; then
+            echo "::error::Root Cargo.toml ($ROOT_VERSION) != crates/core/Cargo.toml ($CORE_VERSION)"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          if [ "$ROOT_VERSION" != "$ODM_VERSION" ]; then
+            echo "::error::Root Cargo.toml ($ROOT_VERSION) != crates/odm/Cargo.toml ($ODM_VERSION)"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          if [ "$ROOT_VERSION" != "$WASM_VERSION" ]; then
+            echo "::error::Root Cargo.toml ($ROOT_VERSION) != crates/wasm/Cargo.toml ($WASM_VERSION)"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          if [ "$ROOT_VERSION" != "$CHANGELOG_VERSION" ]; then
+            echo "::error::Root Cargo.toml ($ROOT_VERSION) != CHANGELOG.md ($CHANGELOG_VERSION)"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          # If triggered by tag, verify tag matches
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION=${GITHUB_REF#refs/tags/v}
+            echo "  Tag version:            $TAG_VERSION"
+            if [ "$ROOT_VERSION" != "$TAG_VERSION" ]; then
+              echo "::error::Tag version ($TAG_VERSION) does not match Cargo.toml ($ROOT_VERSION)"
+              ERRORS=$((ERRORS + 1))
+            fi
+          fi
+
+          if [ $ERRORS -gt 0 ]; then
+            echo ""
+            echo "Version consistency check failed with $ERRORS error(s)"
+            echo "All version files must have the same version number."
+            exit 1
+          fi
+
+          echo ""
+          echo "All versions consistent: $ROOT_VERSION"
+          echo "version=$ROOT_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Restructures CI/CD workflows to fix publish errors and improve organization. Bumps version to 2.0.1.

### New Workflows:

- **version-check.yml** - Standalone version consistency check (no longer checks for `pkg/package.json` which is generated during WASM build)
- **release-sdk.yml** - Publishes to crates.io in correct dependency order (core before sdk)
- **release-cli.yml** - Builds CLI binaries for all platforms, uploads to GitHub release

### Updated Workflows:

- **release-wasm.yml** - Now only runs manually or when called by publish.yml
- **publish.yml** - Clean wrapper that creates release first, then orchestrates all release workflows
- **ci.yml** - Added version-check as the first job

### Fixes:

- crates.io publish error: now publishes `data-modelling-core` before `data-modelling-sdk`
- `pkg/package.json` not found error: removed from version check (it's generated during WASM build)
- release-wasm running on wrong triggers
- Both release-cli and release-wasm now upload artifacts to GitHub release
- Dev releases (version contains `-dev`) are marked as prerelease