### PR TITLE
fix(ci): correct package name in release-wasm sed command

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -89,8 +89,8 @@ jobs:
           cd pkg
           # Update version
           npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
-          # Update package name to scoped package
-          sed -i 's/"name": "data-modelling-sdk"/"name": "@offenedatenmodellierung\/data-modelling-sdk"/' package.json
+          # Update package name to scoped package (wasm-pack uses crate name: data-modelling-wasm)
+          sed -i 's/"name": "data-modelling-wasm"/"name": "@offenedatenmodellierung\/data-modelling-sdk"/' package.json
           # Add repository info
           cat package.json | jq '. + {
             "repository": {


### PR DESCRIPTION
## Summary

Fixes npm publish error where package was being published as `data-modelling-wasm` instead of `@offenedatenmodellierung/data-modelling-sdk`.

### Issue

wasm-pack generates `package.json` with `name: "data-modelling-wasm"` (from the crate name in Cargo.toml), but the sed command was looking for `"data-modelling-sdk"`.

### Fix

Updated the sed pattern to match the actual generated name:
```diff
- sed -i 's/"name": "data-modelling-sdk"/"name": "@offenedatenmodellierung\/data-modelling-sdk"/' package.json
+ sed -i 's/"name": "data-modelling-wasm"/"name": "@offenedatenmodellierung\/data-modelling-sdk"/' package.json
```