### PR TITLE
feat(odcs): add native ODCS data structures for lossless round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2026-01-13
+
+### Added
+
+- **feat(odcs)**: Native ODCS data structures for lossless round-trip
+  - New `ODCSContract` struct representing full ODCS v3.1.0 contracts
+  - New `SchemaObject` struct for schema-level metadata (physicalName, businessName, etc.)
+  - New `Property` struct with nested support (`properties` for OBJECT, `items` for ARRAY)
+  - Supporting types: `QualityRule`, `CustomProperty`, `AuthoritativeDefinition`, `Team`, `Server`, etc.
+  - Converters: `From` trait implementations for Table/Column interop
+  - `ODCSContract::to_tables()` and `ODCSContract::from_tables()` for backwards compatibility
+  - `ODCSContract::to_table_data()` for UI rendering
+
+- **feat(import)**: New `import_contract()` method for native ODCS parsing
+  - Returns `ODCSContract` instead of flattened `Table`/`Column` types
+  - Preserves all contract-level, schema-level, and property-level metadata
+  - Supports nested properties (OBJECT/ARRAY) hierarchically
+  - Multi-table contracts fully supported
+
+- **feat(export)**: New `export_contract()` method for native ODCS serialization
+  - Directly serializes `ODCSContract` to YAML (no reconstruction needed)
+  - Zero data loss on round-trip
+  - `export_contract_validated()` variant with optional schema validation
+
+- **feat(wasm)**: V2 WASM bindings for native ODCS API
+  - `parse_odcs_yaml_v2()` - Returns `ODCSContract` JSON
+  - `export_odcs_yaml_v2()` - Takes `ODCSContract` JSON, returns YAML
+  - `odcs_contract_to_tables()` - Convert contract to Table array
+  - `tables_to_odcs_contract()` - Convert Table array to contract
+  - `odcs_contract_to_table_data()` - Convert contract to TableData for UI
+
 ## [2.0.3] - 2026-01-12
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/core", "crates/odm", "crates/wasm"]
 # Root package for backward compatibility - re-exports data-modelling-core
 [package]
 name = "data-modelling-sdk"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"
@@ -18,7 +18,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 # Re-export core library
-data-modelling-core = { path = "crates/core", version = "2.0.3" }
+data-modelling-core = { path = "crates/core", version = "2.0.4" }
 
 [features]
 default = ["api-backend"]

--- a/LLM.txt
+++ b/LLM.txt
@@ -7,7 +7,7 @@ The Data Modelling SDK is a Rust library that provides unified interfaces for da
 **Repository**: https://github.com/OffeneDatenmodellierung/data-modelling-sdk
 **License**: MIT
 **Rust Edition**: 2024
-**Version**: 2.0.0
+**Version**: 2.0.4
 
 ## Architecture
 
@@ -91,6 +91,13 @@ data-modelling-sdk/
 │   │   ├── domain.rs          # Business Domain schema models (Domain, System, CADSNode, ODCSNode, etc.)
 │   │   ├── enums.rs           # Enums (DatabaseType, MedallionLayer, InfrastructureType, etc.)
 │   │   ├── knowledge.rs       # Knowledge model structs (KnowledgeArticle, ArticleType, ArticleStatus)
+│   │   ├── odcs/              # ODCS native data structures (v2 API)
+│   │   │   ├── mod.rs         # Module exports
+│   │   │   ├── contract.rs    # ODCSContract - root contract document
+│   │   │   ├── schema.rs      # SchemaObject - schema/table definitions
+│   │   │   ├── property.rs    # Property - column/field with nested support
+│   │   │   ├── supporting.rs  # QualityRule, CustomProperty, Team, Server, etc.
+│   │   │   └── converters.rs  # From implementations for Table/Column interop
 │   │   ├── odps.rs            # ODPS model structs (ODPSDataProduct, ODPSInputPort, etc.)
 │   │   ├── openapi.rs         # OpenAPI model structs (OpenAPIModel, OpenAPIFormat) (feature-gated)
 │   │   ├── relationship.rs    # Relationship model
@@ -262,11 +269,34 @@ Core data structures:
 - **`ContactDetails`**: Contact details structure (email, phone, name, role, other)
 - **Enums**: `DatabaseType`, `MedallionLayer`, `SCDPattern`, `DataVaultClassification`, `ModelingLevel`, `Cardinality` (oneToOne, oneToMany, manyToOne, manyToMany), `RelationshipType` (dataFlow, dependency, foreignKey, etl), `EndpointCardinality` (zeroOrOne, exactlyOne, zeroOrMany, oneOrMany), `FlowDirection` (sourceToTarget, targetToSource, bidirectional), `InfrastructureType` (70+ infrastructure types), `CADSKind`, `CADSStatus`, `ODPSStatus`
 
+### ODCS Native Types (`src/models/odcs/`) - v2 API
+
+Native ODCS v3.1.0 data structures for lossless round-trip import/export:
+
+- **`ODCSContract`**: Root data contract document. Contains all contract-level fields: `apiVersion`, `kind`, `id`, `version`, `name`, `status`, `domain`, `dataProduct`, `tenant`, `description`, `schema` (Vec<SchemaObject>), `servers`, `team`, `support`, `roles`, `serviceLevels`, `quality`, `price`, `terms`, `links`, `tags`, `customProperties`
+- **`SchemaObject`**: Schema/table definition within a contract. Contains: `name`, `physicalName`, `physicalType`, `businessName`, `description`, `dataGranularityDescription`, `properties` (Vec<Property>), `relationships`, `quality`, `authoritativeDefinitions`, `customProperties`
+- **`Property`**: Column/field definition with nested support. Contains all ODCS property fields plus: `properties` (Vec<Property> for OBJECT types), `items` (Box<Property> for ARRAY types). Supports arbitrary nesting depth.
+- **`QualityRule`**: Quality rule definition (type, column, description, mustBe, mustNotBe, etc.)
+- **`CustomProperty`**: Key-value custom property (property, value)
+- **`AuthoritativeDefinition`**: External definition reference (type, url)
+- **`Team`**, **`TeamMember`**, **`Support`**, **`Server`**, **`Role`**, **`ServiceLevel`**, **`Price`**, **`Terms`**, **`Link`**: Supporting types for contract metadata
+
+Converters for backwards compatibility:
+- `From<&Property> for Column` - Flattens nested properties to dot-notation
+- `From<&Column> for Property` - Creates flat property from column
+- `From<&SchemaObject> for Table` - Converts schema to table with flattened columns
+- `From<&Table> for SchemaObject` - Reconstructs schema from table
+- `ODCSContract::to_tables()` - Converts contract to Vec<Table>
+- `ODCSContract::from_tables()` - Creates contract from Vec<Table>
+- `ODCSContract::to_table_data()` - Converts contract to Vec<TableData> for UI
+
 ### Import (`src/import/`)
 
 Importers convert various formats to SDK models:
 
 - **`ODCSImporter`**: Primary importer for ODCS v3.1.0 format (also handles legacy ODCL v1.2.1) - for Data Models (tables). Preserves `description`, `quality`, and `$ref` fields. Supports enhanced tags.
+  - `import()` - Returns flattened Table/Column types (v1 API)
+  - `import_contract()` - Returns native ODCSContract with nested properties (v2 API, lossless)
 - **`CADSImporter`**: Importer for CADS v1.0 format - for compute assets (AI/ML models, applications, pipelines). Supports `bpmn_models`, `dmn_models`, and `openapi_specs` references.
 - **`ODPSImporter`**: Importer for ODPS format - for data products linking to ODCS Tables
 - **`BPMNImporter`**: Importer for BPMN 2.0 XML format - for business process models (requires `bpmn` feature)
@@ -286,6 +316,9 @@ Importers convert various formats to SDK models:
 Exporters convert SDK models to various formats:
 
 - **`ODCSExporter`**: Exports to ODCS v3.1.0 format - for Data Models (tables). Preserves all fields including `description`, `quality`, and `$ref`. Supports enhanced tags.
+  - `export_table()` - Exports Table with reconstruction from flattened columns (v1 API)
+  - `export_contract()` - Directly serializes ODCSContract (v2 API, lossless)
+  - `export_contract_validated()` - Same as export_contract() with optional schema validation
 - **`ODCLExporter`**: Exports to ODCL v1.2.1 format - for legacy compatibility
 - **`CADSExporter`**: Exports to CADS v1.0 format - for compute assets. Supports `bpmn_models`, `dmn_models`, and `openapi_specs` references.
 - **`ODPSExporter`**: Exports to ODPS format - for data products

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-core"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/crates/core/src/import/mod.rs
+++ b/crates/core/src/import/mod.rs
@@ -110,6 +110,20 @@ pub struct TableData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<serde_json::Value>,
 
+    // === Schema Object Level Fields (ODCS v3.1.0) ===
+    /// Physical name of the schema object (ODCS: schema[].physicalName)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub physical_name: Option<String>,
+    /// Physical type of the schema object (ODCS: schema[].physicalType)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub physical_type: Option<String>,
+    /// Business name of the schema object (ODCS: schema[].businessName)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub business_name: Option<String>,
+    /// Data granularity description (ODCS: schema[].dataGranularityDescription)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_granularity_description: Option<String>,
+
     // === Schema/Columns ===
     /// Column definitions (from ODCS schema.properties)
     pub columns: Vec<ColumnData>,

--- a/crates/core/src/import/odcl.rs
+++ b/crates/core/src/import/odcl.rs
@@ -152,6 +152,11 @@ impl ODCLImporter {
                         .get("info")
                         .and_then(|v| v.get("description"))
                         .cloned(),
+                    // Schema-level fields (ODCL doesn't have these at schema level)
+                    physical_name: table.schema_name.clone(),
+                    physical_type: None,
+                    business_name: None,
+                    data_granularity_description: None,
                     columns: table.columns.iter().map(column_to_column_data).collect(),
                     servers: json_data
                         .get("servers")

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -16,6 +16,7 @@ pub mod domain;
 pub mod domain_config;
 pub mod enums;
 pub mod knowledge;
+pub mod odcs;
 pub mod odps;
 #[cfg(feature = "openapi")]
 pub mod openapi;

--- a/crates/core/src/models/odcs/contract.rs
+++ b/crates/core/src/models/odcs/contract.rs
@@ -1,0 +1,502 @@
+//! ODCSContract type for ODCS native data structures
+//!
+//! Represents the root data contract document following the ODCS v3.1.0 specification.
+
+use super::schema::SchemaObject;
+use super::supporting::{
+    AuthoritativeDefinition, CustomProperty, Description, Link, Price, QualityRule, Role, Server,
+    ServiceLevel, Support, Team, Terms,
+};
+use serde::{Deserialize, Serialize};
+
+/// ODCSContract - the root data contract document (ODCS v3.1.0)
+///
+/// This is the top-level structure that represents an entire ODCS data contract.
+/// It contains all contract-level metadata plus one or more schema objects (tables).
+///
+/// # Example
+///
+/// ```rust
+/// use data_modelling_core::models::odcs::{ODCSContract, SchemaObject, Property};
+///
+/// let contract = ODCSContract::new("customer-contract", "v1.0.0")
+///     .with_domain("retail")
+///     .with_status("active")
+///     .with_schema(
+///         SchemaObject::new("customers")
+///             .with_physical_type("table")
+///             .with_properties(vec![
+///                 Property::new("id", "integer").with_primary_key(true),
+///                 Property::new("name", "string").with_required(true),
+///             ])
+///     );
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ODCSContract {
+    // === Required Identity Fields ===
+    /// API version (e.g., "v3.1.0")
+    pub api_version: String,
+    /// Kind identifier (always "DataContract")
+    pub kind: String,
+    /// Unique contract ID (UUID or other identifier)
+    pub id: String,
+    /// Contract version (semantic versioning recommended)
+    pub version: String,
+    /// Contract name
+    pub name: String,
+
+    // === Status ===
+    /// Contract status: "draft", "active", "deprecated", "retired"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+
+    // === Organization ===
+    /// Domain this contract belongs to
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    /// Data product this contract belongs to
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_product: Option<String>,
+    /// Tenant identifier for multi-tenant systems
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+
+    // === Description ===
+    /// Contract description (can be simple string or structured object)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<Description>,
+
+    // === Schema (Tables) ===
+    /// Schema objects (tables, views, topics) in this contract
+    #[serde(default)]
+    pub schema: Vec<SchemaObject>,
+
+    // === Configuration ===
+    /// Server configurations
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub servers: Vec<Server>,
+    /// Team information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team: Option<Team>,
+    /// Support information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub support: Option<Support>,
+    /// Role definitions
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<Role>,
+
+    // === SLA & Quality ===
+    /// Service level agreements
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub service_levels: Vec<ServiceLevel>,
+    /// Contract-level quality rules
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub quality: Vec<QualityRule>,
+
+    // === Pricing & Terms ===
+    /// Price information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<Price>,
+    /// Terms and conditions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terms: Option<Terms>,
+
+    // === Links & References ===
+    /// External links
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<Link>,
+    /// Authoritative definitions
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authoritative_definitions: Vec<AuthoritativeDefinition>,
+
+    // === Tags & Custom Properties ===
+    /// Contract-level tags
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// Custom properties for format-specific metadata
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_properties: Vec<CustomProperty>,
+
+    // === Timestamps ===
+    /// Contract creation timestamp (ISO 8601)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_created_ts: Option<String>,
+}
+
+impl Default for ODCSContract {
+    fn default() -> Self {
+        Self {
+            api_version: "v3.1.0".to_string(),
+            kind: "DataContract".to_string(),
+            id: String::new(),
+            version: "1.0.0".to_string(),
+            name: String::new(),
+            status: None,
+            domain: None,
+            data_product: None,
+            tenant: None,
+            description: None,
+            schema: Vec::new(),
+            servers: Vec::new(),
+            team: None,
+            support: None,
+            roles: Vec::new(),
+            service_levels: Vec::new(),
+            quality: Vec::new(),
+            price: None,
+            terms: None,
+            links: Vec::new(),
+            authoritative_definitions: Vec::new(),
+            tags: Vec::new(),
+            custom_properties: Vec::new(),
+            contract_created_ts: None,
+        }
+    }
+}
+
+impl ODCSContract {
+    /// Create a new contract with the given name and version
+    pub fn new(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            id: uuid::Uuid::new_v4().to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Create a new contract with a specific ID
+    pub fn new_with_id(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        version: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            version: version.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set the API version
+    pub fn with_api_version(mut self, api_version: impl Into<String>) -> Self {
+        self.api_version = api_version.into();
+        self
+    }
+
+    /// Set the status
+    pub fn with_status(mut self, status: impl Into<String>) -> Self {
+        self.status = Some(status.into());
+        self
+    }
+
+    /// Set the domain
+    pub fn with_domain(mut self, domain: impl Into<String>) -> Self {
+        self.domain = Some(domain.into());
+        self
+    }
+
+    /// Set the data product
+    pub fn with_data_product(mut self, data_product: impl Into<String>) -> Self {
+        self.data_product = Some(data_product.into());
+        self
+    }
+
+    /// Set the tenant
+    pub fn with_tenant(mut self, tenant: impl Into<String>) -> Self {
+        self.tenant = Some(tenant.into());
+        self
+    }
+
+    /// Set the description (simple string)
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(Description::Simple(description.into()));
+        self
+    }
+
+    /// Set a structured description
+    pub fn with_structured_description(mut self, description: Description) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    /// Add a schema object
+    pub fn with_schema(mut self, schema: SchemaObject) -> Self {
+        self.schema.push(schema);
+        self
+    }
+
+    /// Set all schema objects
+    pub fn with_schemas(mut self, schemas: Vec<SchemaObject>) -> Self {
+        self.schema = schemas;
+        self
+    }
+
+    /// Add a server configuration
+    pub fn with_server(mut self, server: Server) -> Self {
+        self.servers.push(server);
+        self
+    }
+
+    /// Set the team information
+    pub fn with_team(mut self, team: Team) -> Self {
+        self.team = Some(team);
+        self
+    }
+
+    /// Set the support information
+    pub fn with_support(mut self, support: Support) -> Self {
+        self.support = Some(support);
+        self
+    }
+
+    /// Add a role
+    pub fn with_role(mut self, role: Role) -> Self {
+        self.roles.push(role);
+        self
+    }
+
+    /// Add a service level
+    pub fn with_service_level(mut self, service_level: ServiceLevel) -> Self {
+        self.service_levels.push(service_level);
+        self
+    }
+
+    /// Add a quality rule
+    pub fn with_quality_rule(mut self, rule: QualityRule) -> Self {
+        self.quality.push(rule);
+        self
+    }
+
+    /// Set the price
+    pub fn with_price(mut self, price: Price) -> Self {
+        self.price = Some(price);
+        self
+    }
+
+    /// Set the terms
+    pub fn with_terms(mut self, terms: Terms) -> Self {
+        self.terms = Some(terms);
+        self
+    }
+
+    /// Add a link
+    pub fn with_link(mut self, link: Link) -> Self {
+        self.links.push(link);
+        self
+    }
+
+    /// Add an authoritative definition
+    pub fn with_authoritative_definition(mut self, definition: AuthoritativeDefinition) -> Self {
+        self.authoritative_definitions.push(definition);
+        self
+    }
+
+    /// Add a tag
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Set all tags
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = tags;
+        self
+    }
+
+    /// Add a custom property
+    pub fn with_custom_property(mut self, custom_property: CustomProperty) -> Self {
+        self.custom_properties.push(custom_property);
+        self
+    }
+
+    /// Set the contract creation timestamp
+    pub fn with_contract_created_ts(mut self, timestamp: impl Into<String>) -> Self {
+        self.contract_created_ts = Some(timestamp.into());
+        self
+    }
+
+    /// Get the number of schema objects
+    pub fn schema_count(&self) -> usize {
+        self.schema.len()
+    }
+
+    /// Get a schema object by name
+    pub fn get_schema(&self, name: &str) -> Option<&SchemaObject> {
+        self.schema.iter().find(|s| s.name == name)
+    }
+
+    /// Get a mutable schema object by name
+    pub fn get_schema_mut(&mut self, name: &str) -> Option<&mut SchemaObject> {
+        self.schema.iter_mut().find(|s| s.name == name)
+    }
+
+    /// Get all schema names
+    pub fn schema_names(&self) -> Vec<&str> {
+        self.schema.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    /// Check if this is a multi-table contract
+    pub fn is_multi_table(&self) -> bool {
+        self.schema.len() > 1
+    }
+
+    /// Get the first schema (for single-table contracts)
+    pub fn first_schema(&self) -> Option<&SchemaObject> {
+        self.schema.first()
+    }
+
+    /// Get the description as a simple string
+    pub fn description_string(&self) -> Option<String> {
+        self.description.as_ref().map(|d| d.as_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::odcs::Property;
+
+    #[test]
+    fn test_contract_creation() {
+        let contract = ODCSContract::new("my-contract", "1.0.0")
+            .with_domain("retail")
+            .with_status("active");
+
+        assert_eq!(contract.name, "my-contract");
+        assert_eq!(contract.version, "1.0.0");
+        assert_eq!(contract.domain, Some("retail".to_string()));
+        assert_eq!(contract.status, Some("active".to_string()));
+        assert_eq!(contract.api_version, "v3.1.0");
+        assert_eq!(contract.kind, "DataContract");
+        assert!(!contract.id.is_empty()); // UUID was generated
+    }
+
+    #[test]
+    fn test_contract_with_schema() {
+        let contract = ODCSContract::new("order-contract", "2.0.0")
+            .with_schema(
+                SchemaObject::new("orders")
+                    .with_physical_type("table")
+                    .with_properties(vec![
+                        Property::new("id", "integer").with_primary_key(true),
+                        Property::new("customer_id", "integer"),
+                        Property::new("total", "number"),
+                    ]),
+            )
+            .with_schema(
+                SchemaObject::new("order_items")
+                    .with_physical_type("table")
+                    .with_properties(vec![
+                        Property::new("id", "integer").with_primary_key(true),
+                        Property::new("order_id", "integer"),
+                        Property::new("product_id", "integer"),
+                    ]),
+            );
+
+        assert_eq!(contract.schema_count(), 2);
+        assert!(contract.is_multi_table());
+        assert_eq!(contract.schema_names(), vec!["orders", "order_items"]);
+
+        let orders = contract.get_schema("orders");
+        assert!(orders.is_some());
+        assert_eq!(orders.unwrap().property_count(), 3);
+    }
+
+    #[test]
+    fn test_contract_serialization() {
+        let contract = ODCSContract::new_with_id(
+            "550e8400-e29b-41d4-a716-446655440000",
+            "test-contract",
+            "1.0.0",
+        )
+        .with_domain("test")
+        .with_status("draft")
+        .with_description("A test contract")
+        .with_tag("test")
+        .with_schema(SchemaObject::new("test_table").with_property(Property::new("id", "string")));
+
+        let json = serde_json::to_string_pretty(&contract).unwrap();
+
+        assert!(json.contains("\"apiVersion\": \"v3.1.0\""));
+        assert!(json.contains("\"kind\": \"DataContract\""));
+        assert!(json.contains("\"id\": \"550e8400-e29b-41d4-a716-446655440000\""));
+        assert!(json.contains("\"name\": \"test-contract\""));
+        assert!(json.contains("\"domain\": \"test\""));
+        assert!(json.contains("\"status\": \"draft\""));
+
+        // Verify camelCase
+        assert!(json.contains("apiVersion"));
+        assert!(!json.contains("api_version"));
+    }
+
+    #[test]
+    fn test_contract_deserialization() {
+        let json = r#"{
+            "apiVersion": "v3.1.0",
+            "kind": "DataContract",
+            "id": "test-id-123",
+            "version": "2.0.0",
+            "name": "customer-contract",
+            "status": "active",
+            "domain": "customers",
+            "description": "Customer data contract",
+            "schema": [
+                {
+                    "name": "customers",
+                    "physicalType": "table",
+                    "properties": [
+                        {
+                            "name": "id",
+                            "logicalType": "integer",
+                            "primaryKey": true
+                        },
+                        {
+                            "name": "name",
+                            "logicalType": "string",
+                            "required": true
+                        }
+                    ]
+                }
+            ],
+            "tags": ["customer", "pii"]
+        }"#;
+
+        let contract: ODCSContract = serde_json::from_str(json).unwrap();
+        assert_eq!(contract.api_version, "v3.1.0");
+        assert_eq!(contract.kind, "DataContract");
+        assert_eq!(contract.id, "test-id-123");
+        assert_eq!(contract.version, "2.0.0");
+        assert_eq!(contract.name, "customer-contract");
+        assert_eq!(contract.status, Some("active".to_string()));
+        assert_eq!(contract.domain, Some("customers".to_string()));
+        assert_eq!(contract.schema_count(), 1);
+        assert_eq!(contract.tags, vec!["customer", "pii"]);
+
+        let customers = contract.get_schema("customers").unwrap();
+        assert_eq!(customers.property_count(), 2);
+    }
+
+    #[test]
+    fn test_structured_description() {
+        let json = r#"{
+            "apiVersion": "v3.1.0",
+            "kind": "DataContract",
+            "id": "test",
+            "version": "1.0.0",
+            "name": "test",
+            "description": {
+                "purpose": "Store customer information",
+                "usage": "Read-only access for analytics"
+            }
+        }"#;
+
+        let contract: ODCSContract = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            contract.description_string(),
+            Some("Store customer information".to_string())
+        );
+    }
+}

--- a/crates/core/src/models/odcs/converters.rs
+++ b/crates/core/src/models/odcs/converters.rs
@@ -1,0 +1,1001 @@
+//! Converters between ODCS native types and legacy Table/Column types
+//!
+//! These converters enable backwards compatibility with existing APIs while
+//! allowing the new ODCS-native types to be used internally.
+
+use super::contract::ODCSContract;
+use super::property::Property;
+use super::schema::SchemaObject;
+use super::supporting::{
+    AuthoritativeDefinition as OdcsAuthDef, CustomProperty,
+    LogicalTypeOptions as OdcsLogicalTypeOptions, PropertyRelationship as OdcsPropertyRelationship,
+};
+use crate::import::{ColumnData, TableData};
+use crate::models::column::{
+    AuthoritativeDefinition as ColumnAuthDef, Column,
+    LogicalTypeOptions as ColumnLogicalTypeOptions,
+    PropertyRelationship as ColumnPropertyRelationship,
+};
+use crate::models::table::Table;
+
+// ============================================================================
+// Property <-> Column Converters
+// ============================================================================
+
+impl From<&Property> for Column {
+    /// Convert a Property to a Column
+    ///
+    /// This flattens nested properties to dot-notation names for backwards compatibility.
+    /// For example, a nested property `address.street` becomes a column named "address.street".
+    fn from(prop: &Property) -> Self {
+        Column {
+            id: prop.id.clone(),
+            name: prop.name.clone(),
+            business_name: prop.business_name.clone(),
+            description: prop.description.clone().unwrap_or_default(),
+            data_type: prop.logical_type.clone(),
+            physical_type: prop.physical_type.clone(),
+            physical_name: prop.physical_name.clone(),
+            logical_type_options: prop.logical_type_options.as_ref().map(|opts| {
+                ColumnLogicalTypeOptions {
+                    min_length: opts.min_length,
+                    max_length: opts.max_length,
+                    pattern: opts.pattern.clone(),
+                    format: opts.format.clone(),
+                    minimum: opts.minimum.clone(),
+                    maximum: opts.maximum.clone(),
+                    exclusive_minimum: opts.exclusive_minimum.clone(),
+                    exclusive_maximum: opts.exclusive_maximum.clone(),
+                    precision: opts.precision,
+                    scale: opts.scale,
+                }
+            }),
+            primary_key: prop.primary_key,
+            primary_key_position: prop.primary_key_position,
+            unique: prop.unique,
+            nullable: !prop.required, // ODCS uses required, Column uses nullable (inverse)
+            partitioned: prop.partitioned,
+            partition_key_position: prop.partition_key_position,
+            clustered: prop.clustered,
+            classification: prop.classification.clone(),
+            critical_data_element: prop.critical_data_element,
+            encrypted_name: prop.encrypted_name.clone(),
+            transform_source_objects: prop.transform_source_objects.clone(),
+            transform_logic: prop.transform_logic.clone(),
+            transform_description: prop.transform_description.clone(),
+            examples: prop.examples.clone(),
+            default_value: prop.default_value.clone(),
+            relationships: prop
+                .relationships
+                .iter()
+                .map(|r| ColumnPropertyRelationship {
+                    relationship_type: r.relationship_type.clone(),
+                    to: r.to.clone(),
+                })
+                .collect(),
+            authoritative_definitions: prop
+                .authoritative_definitions
+                .iter()
+                .map(|d| ColumnAuthDef {
+                    definition_type: d.definition_type.clone(),
+                    url: d.url.clone(),
+                })
+                .collect(),
+            quality: prop
+                .quality
+                .iter()
+                .map(|q| serde_json::to_value(q).ok())
+                .filter_map(|v| v.and_then(|v| v.as_object().cloned()))
+                .map(|m| m.into_iter().collect())
+                .collect(),
+            enum_values: prop.enum_values.clone(),
+            tags: prop.tags.clone(),
+            custom_properties: prop
+                .custom_properties
+                .iter()
+                .map(|cp| (cp.property.clone(), cp.value.clone()))
+                .collect(),
+            // Legacy fields - default values
+            secondary_key: false,
+            composite_key: None,
+            foreign_key: None,
+            constraints: Vec::new(),
+            errors: Vec::new(),
+            column_order: 0,
+            nested_data: None,
+        }
+    }
+}
+
+impl From<&Column> for Property {
+    /// Convert a Column to a Property
+    ///
+    /// Note: This creates a flat property. To reconstruct nested structure from
+    /// dot-notation column names, use `Property::from_flat_paths()`.
+    fn from(col: &Column) -> Self {
+        Property {
+            id: col.id.clone(),
+            name: col.name.clone(),
+            business_name: col.business_name.clone(),
+            description: if col.description.is_empty() {
+                None
+            } else {
+                Some(col.description.clone())
+            },
+            logical_type: col.data_type.clone(),
+            physical_type: col.physical_type.clone(),
+            physical_name: col.physical_name.clone(),
+            logical_type_options: col.logical_type_options.as_ref().map(|opts| {
+                OdcsLogicalTypeOptions {
+                    min_length: opts.min_length,
+                    max_length: opts.max_length,
+                    pattern: opts.pattern.clone(),
+                    format: opts.format.clone(),
+                    minimum: opts.minimum.clone(),
+                    maximum: opts.maximum.clone(),
+                    exclusive_minimum: opts.exclusive_minimum.clone(),
+                    exclusive_maximum: opts.exclusive_maximum.clone(),
+                    precision: opts.precision,
+                    scale: opts.scale,
+                }
+            }),
+            required: !col.nullable, // Column uses nullable, ODCS uses required (inverse)
+            primary_key: col.primary_key,
+            primary_key_position: col.primary_key_position,
+            unique: col.unique,
+            partitioned: col.partitioned,
+            partition_key_position: col.partition_key_position,
+            clustered: col.clustered,
+            classification: col.classification.clone(),
+            critical_data_element: col.critical_data_element,
+            encrypted_name: col.encrypted_name.clone(),
+            transform_source_objects: col.transform_source_objects.clone(),
+            transform_logic: col.transform_logic.clone(),
+            transform_description: col.transform_description.clone(),
+            examples: col.examples.clone(),
+            default_value: col.default_value.clone(),
+            relationships: col
+                .relationships
+                .iter()
+                .map(|r| OdcsPropertyRelationship {
+                    relationship_type: r.relationship_type.clone(),
+                    to: r.to.clone(),
+                })
+                .collect(),
+            authoritative_definitions: col
+                .authoritative_definitions
+                .iter()
+                .map(|d| OdcsAuthDef {
+                    definition_type: d.definition_type.clone(),
+                    url: d.url.clone(),
+                })
+                .collect(),
+            quality: col
+                .quality
+                .iter()
+                .filter_map(|q| serde_json::to_value(q).ok())
+                .filter_map(|v| serde_json::from_value(v).ok())
+                .collect(),
+            enum_values: col.enum_values.clone(),
+            tags: col.tags.clone(),
+            custom_properties: col
+                .custom_properties
+                .iter()
+                .map(|(k, v)| CustomProperty::new(k.clone(), v.clone()))
+                .collect(),
+            items: None,
+            properties: Vec::new(),
+        }
+    }
+}
+
+// ============================================================================
+// SchemaObject <-> Table Converters
+// ============================================================================
+
+impl From<&SchemaObject> for Table {
+    /// Convert a SchemaObject to a Table
+    ///
+    /// This flattens nested properties to dot-notation column names.
+    fn from(schema: &SchemaObject) -> Self {
+        // Flatten all properties to columns with dot-notation names
+        let columns = flatten_properties_to_columns(&schema.properties, "");
+
+        let mut table = Table::new(schema.name.clone(), columns);
+
+        // Set schema-level fields
+        table.schema_name = schema.physical_name.clone();
+
+        // Store schema-level metadata in odcl_metadata
+        if let Some(ref id) = schema.id {
+            table
+                .odcl_metadata
+                .insert("schemaId".to_string(), serde_json::json!(id));
+        }
+        if let Some(ref physical_name) = schema.physical_name {
+            table
+                .odcl_metadata
+                .insert("physicalName".to_string(), serde_json::json!(physical_name));
+        }
+        if let Some(ref physical_type) = schema.physical_type {
+            table
+                .odcl_metadata
+                .insert("physicalType".to_string(), serde_json::json!(physical_type));
+        }
+        if let Some(ref business_name) = schema.business_name {
+            table
+                .odcl_metadata
+                .insert("businessName".to_string(), serde_json::json!(business_name));
+        }
+        if let Some(ref description) = schema.description {
+            table.odcl_metadata.insert(
+                "schemaDescription".to_string(),
+                serde_json::json!(description),
+            );
+        }
+        if let Some(ref granularity) = schema.data_granularity_description {
+            table.odcl_metadata.insert(
+                "dataGranularityDescription".to_string(),
+                serde_json::json!(granularity),
+            );
+        }
+        if !schema.tags.is_empty() {
+            table
+                .odcl_metadata
+                .insert("schemaTags".to_string(), serde_json::json!(schema.tags));
+        }
+        if !schema.relationships.is_empty() {
+            table.odcl_metadata.insert(
+                "schemaRelationships".to_string(),
+                serde_json::to_value(&schema.relationships).unwrap_or_default(),
+            );
+        }
+        if !schema.quality.is_empty() {
+            table.quality = schema
+                .quality
+                .iter()
+                .filter_map(|q| serde_json::to_value(q).ok())
+                .filter_map(|v| v.as_object().cloned())
+                .map(|m| m.into_iter().collect())
+                .collect();
+        }
+        if !schema.authoritative_definitions.is_empty() {
+            table.odcl_metadata.insert(
+                "authoritativeDefinitions".to_string(),
+                serde_json::to_value(&schema.authoritative_definitions).unwrap_or_default(),
+            );
+        }
+        if !schema.custom_properties.is_empty() {
+            table.odcl_metadata.insert(
+                "customProperties".to_string(),
+                serde_json::to_value(&schema.custom_properties).unwrap_or_default(),
+            );
+        }
+
+        table
+    }
+}
+
+/// Helper function to flatten nested properties to columns with dot-notation names
+fn flatten_properties_to_columns(properties: &[Property], prefix: &str) -> Vec<Column> {
+    let mut columns = Vec::new();
+
+    for prop in properties {
+        let full_name = if prefix.is_empty() {
+            prop.name.clone()
+        } else {
+            format!("{}.{}", prefix, prop.name)
+        };
+
+        // Create column for this property
+        let mut col = Column::from(prop);
+        col.name = full_name.clone();
+
+        columns.push(col);
+
+        // Recursively flatten nested object properties
+        if !prop.properties.is_empty() {
+            let nested = flatten_properties_to_columns(&prop.properties, &full_name);
+            columns.extend(nested);
+        }
+
+        // Handle array items
+        if let Some(ref items) = prop.items {
+            let items_prefix = format!("{}.[]", full_name);
+            let mut items_col = Column::from(items.as_ref());
+            items_col.name = items_prefix.clone();
+            columns.push(items_col);
+
+            // Recursively flatten array item properties
+            if !items.properties.is_empty() {
+                let nested = flatten_properties_to_columns(&items.properties, &items_prefix);
+                columns.extend(nested);
+            }
+        }
+    }
+
+    columns
+}
+
+impl From<&Table> for SchemaObject {
+    /// Convert a Table to a SchemaObject
+    ///
+    /// This reconstructs nested property structure from dot-notation column names.
+    fn from(table: &Table) -> Self {
+        // Build flat property list first
+        let flat_props: Vec<(String, Property)> = table
+            .columns
+            .iter()
+            .map(|col| (col.name.clone(), Property::from(col)))
+            .collect();
+
+        // Reconstruct nested structure
+        let properties = Property::from_flat_paths(&flat_props);
+
+        let mut schema = SchemaObject::new(table.name.clone()).with_properties(properties);
+
+        // Extract schema-level metadata from odcl_metadata
+        if let Some(id) = table.odcl_metadata.get("schemaId").and_then(|v| v.as_str()) {
+            schema.id = Some(id.to_string());
+        }
+        if let Some(physical_name) = table
+            .odcl_metadata
+            .get("physicalName")
+            .and_then(|v| v.as_str())
+        {
+            schema.physical_name = Some(physical_name.to_string());
+        } else if let Some(ref sn) = table.schema_name {
+            schema.physical_name = Some(sn.clone());
+        }
+        if let Some(physical_type) = table
+            .odcl_metadata
+            .get("physicalType")
+            .and_then(|v| v.as_str())
+        {
+            schema.physical_type = Some(physical_type.to_string());
+        }
+        if let Some(business_name) = table
+            .odcl_metadata
+            .get("businessName")
+            .and_then(|v| v.as_str())
+        {
+            schema.business_name = Some(business_name.to_string());
+        }
+        if let Some(description) = table
+            .odcl_metadata
+            .get("schemaDescription")
+            .and_then(|v| v.as_str())
+        {
+            schema.description = Some(description.to_string());
+        }
+        if let Some(granularity) = table
+            .odcl_metadata
+            .get("dataGranularityDescription")
+            .and_then(|v| v.as_str())
+        {
+            schema.data_granularity_description = Some(granularity.to_string());
+        }
+        if let Some(tags) = table.odcl_metadata.get("schemaTags")
+            && let Ok(parsed_tags) = serde_json::from_value::<Vec<String>>(tags.clone())
+        {
+            schema.tags = parsed_tags;
+        }
+        if let Some(rels) = table.odcl_metadata.get("schemaRelationships")
+            && let Ok(parsed_rels) = serde_json::from_value(rels.clone())
+        {
+            schema.relationships = parsed_rels;
+        }
+        if !table.quality.is_empty() {
+            schema.quality = table
+                .quality
+                .iter()
+                .filter_map(|q| serde_json::to_value(q).ok())
+                .filter_map(|v| serde_json::from_value(v).ok())
+                .collect();
+        }
+        if let Some(auth_defs) = table.odcl_metadata.get("authoritativeDefinitions")
+            && let Ok(parsed) = serde_json::from_value(auth_defs.clone())
+        {
+            schema.authoritative_definitions = parsed;
+        }
+        if let Some(custom) = table.odcl_metadata.get("customProperties")
+            && let Ok(parsed) = serde_json::from_value(custom.clone())
+        {
+            schema.custom_properties = parsed;
+        }
+
+        schema
+    }
+}
+
+// ============================================================================
+// ODCSContract <-> Vec<Table> Converters
+// ============================================================================
+
+impl ODCSContract {
+    /// Convert the contract to a vector of Tables
+    ///
+    /// Each SchemaObject becomes a Table, with contract-level metadata
+    /// stored in each table's odcl_metadata.
+    pub fn to_tables(&self) -> Vec<Table> {
+        self.schema
+            .iter()
+            .map(|schema| {
+                let mut table = Table::from(schema);
+
+                // Store contract-level metadata
+                table.odcl_metadata.insert(
+                    "apiVersion".to_string(),
+                    serde_json::json!(self.api_version),
+                );
+                table
+                    .odcl_metadata
+                    .insert("kind".to_string(), serde_json::json!(self.kind));
+                table
+                    .odcl_metadata
+                    .insert("contractId".to_string(), serde_json::json!(self.id));
+                table
+                    .odcl_metadata
+                    .insert("version".to_string(), serde_json::json!(self.version));
+                table
+                    .odcl_metadata
+                    .insert("contractName".to_string(), serde_json::json!(self.name));
+
+                if let Some(ref status) = self.status {
+                    table
+                        .odcl_metadata
+                        .insert("status".to_string(), serde_json::json!(status));
+                }
+                if let Some(ref domain) = self.domain {
+                    table
+                        .odcl_metadata
+                        .insert("domain".to_string(), serde_json::json!(domain));
+                }
+                if let Some(ref data_product) = self.data_product {
+                    table
+                        .odcl_metadata
+                        .insert("dataProduct".to_string(), serde_json::json!(data_product));
+                }
+                if let Some(ref tenant) = self.tenant {
+                    table
+                        .odcl_metadata
+                        .insert("tenant".to_string(), serde_json::json!(tenant));
+                }
+                if let Some(ref description) = self.description {
+                    table.odcl_metadata.insert(
+                        "description".to_string(),
+                        serde_json::to_value(description).unwrap_or_default(),
+                    );
+                }
+                if !self.servers.is_empty() {
+                    table.odcl_metadata.insert(
+                        "servers".to_string(),
+                        serde_json::to_value(&self.servers).unwrap_or_default(),
+                    );
+                }
+                if let Some(ref team) = self.team {
+                    table.odcl_metadata.insert(
+                        "team".to_string(),
+                        serde_json::to_value(team).unwrap_or_default(),
+                    );
+                }
+                if let Some(ref support) = self.support {
+                    table.odcl_metadata.insert(
+                        "support".to_string(),
+                        serde_json::to_value(support).unwrap_or_default(),
+                    );
+                }
+                if !self.roles.is_empty() {
+                    table.odcl_metadata.insert(
+                        "roles".to_string(),
+                        serde_json::to_value(&self.roles).unwrap_or_default(),
+                    );
+                }
+                if !self.service_levels.is_empty() {
+                    table.odcl_metadata.insert(
+                        "serviceLevels".to_string(),
+                        serde_json::to_value(&self.service_levels).unwrap_or_default(),
+                    );
+                }
+                if !self.quality.is_empty() {
+                    table.odcl_metadata.insert(
+                        "contractQuality".to_string(),
+                        serde_json::to_value(&self.quality).unwrap_or_default(),
+                    );
+                }
+                if let Some(ref price) = self.price {
+                    table.odcl_metadata.insert(
+                        "price".to_string(),
+                        serde_json::to_value(price).unwrap_or_default(),
+                    );
+                }
+                if let Some(ref terms) = self.terms {
+                    table.odcl_metadata.insert(
+                        "terms".to_string(),
+                        serde_json::to_value(terms).unwrap_or_default(),
+                    );
+                }
+                if !self.links.is_empty() {
+                    table.odcl_metadata.insert(
+                        "links".to_string(),
+                        serde_json::to_value(&self.links).unwrap_or_default(),
+                    );
+                }
+                if !self.authoritative_definitions.is_empty() {
+                    table.odcl_metadata.insert(
+                        "contractAuthoritativeDefinitions".to_string(),
+                        serde_json::to_value(&self.authoritative_definitions).unwrap_or_default(),
+                    );
+                }
+                if !self.tags.is_empty() {
+                    table
+                        .odcl_metadata
+                        .insert("contractTags".to_string(), serde_json::json!(self.tags));
+                }
+                if !self.custom_properties.is_empty() {
+                    table.odcl_metadata.insert(
+                        "contractCustomProperties".to_string(),
+                        serde_json::to_value(&self.custom_properties).unwrap_or_default(),
+                    );
+                }
+                if let Some(ref ts) = self.contract_created_ts {
+                    table
+                        .odcl_metadata
+                        .insert("contractCreatedTs".to_string(), serde_json::json!(ts));
+                }
+
+                table
+            })
+            .collect()
+    }
+
+    /// Create a contract from a vector of Tables
+    ///
+    /// Contract-level metadata is extracted from the first table's odcl_metadata.
+    /// Each table becomes a SchemaObject.
+    pub fn from_tables(tables: &[Table]) -> Self {
+        if tables.is_empty() {
+            return ODCSContract::default();
+        }
+
+        let first_table = &tables[0];
+        let mut contract = ODCSContract::default();
+
+        // Extract contract-level metadata from first table
+        if let Some(api_version) = first_table
+            .odcl_metadata
+            .get("apiVersion")
+            .and_then(|v| v.as_str())
+        {
+            contract.api_version = api_version.to_string();
+        }
+        if let Some(kind) = first_table
+            .odcl_metadata
+            .get("kind")
+            .and_then(|v| v.as_str())
+        {
+            contract.kind = kind.to_string();
+        }
+        if let Some(id) = first_table
+            .odcl_metadata
+            .get("contractId")
+            .and_then(|v| v.as_str())
+        {
+            contract.id = id.to_string();
+        }
+        if let Some(version) = first_table
+            .odcl_metadata
+            .get("version")
+            .and_then(|v| v.as_str())
+        {
+            contract.version = version.to_string();
+        }
+        if let Some(name) = first_table
+            .odcl_metadata
+            .get("contractName")
+            .and_then(|v| v.as_str())
+        {
+            contract.name = name.to_string();
+        }
+        if let Some(status) = first_table
+            .odcl_metadata
+            .get("status")
+            .and_then(|v| v.as_str())
+        {
+            contract.status = Some(status.to_string());
+        }
+        if let Some(domain) = first_table
+            .odcl_metadata
+            .get("domain")
+            .and_then(|v| v.as_str())
+        {
+            contract.domain = Some(domain.to_string());
+        }
+        if let Some(data_product) = first_table
+            .odcl_metadata
+            .get("dataProduct")
+            .and_then(|v| v.as_str())
+        {
+            contract.data_product = Some(data_product.to_string());
+        }
+        if let Some(tenant) = first_table
+            .odcl_metadata
+            .get("tenant")
+            .and_then(|v| v.as_str())
+        {
+            contract.tenant = Some(tenant.to_string());
+        }
+        if let Some(description) = first_table.odcl_metadata.get("description") {
+            contract.description = serde_json::from_value(description.clone()).ok();
+        }
+        if let Some(servers) = first_table.odcl_metadata.get("servers") {
+            contract.servers = serde_json::from_value(servers.clone()).unwrap_or_default();
+        }
+        if let Some(team) = first_table.odcl_metadata.get("team") {
+            contract.team = serde_json::from_value(team.clone()).ok();
+        }
+        if let Some(support) = first_table.odcl_metadata.get("support") {
+            contract.support = serde_json::from_value(support.clone()).ok();
+        }
+        if let Some(roles) = first_table.odcl_metadata.get("roles") {
+            contract.roles = serde_json::from_value(roles.clone()).unwrap_or_default();
+        }
+        if let Some(service_levels) = first_table.odcl_metadata.get("serviceLevels") {
+            contract.service_levels =
+                serde_json::from_value(service_levels.clone()).unwrap_or_default();
+        }
+        if let Some(quality) = first_table.odcl_metadata.get("contractQuality") {
+            contract.quality = serde_json::from_value(quality.clone()).unwrap_or_default();
+        }
+        if let Some(price) = first_table.odcl_metadata.get("price") {
+            contract.price = serde_json::from_value(price.clone()).ok();
+        }
+        if let Some(terms) = first_table.odcl_metadata.get("terms") {
+            contract.terms = serde_json::from_value(terms.clone()).ok();
+        }
+        if let Some(links) = first_table.odcl_metadata.get("links") {
+            contract.links = serde_json::from_value(links.clone()).unwrap_or_default();
+        }
+        if let Some(auth_defs) = first_table
+            .odcl_metadata
+            .get("contractAuthoritativeDefinitions")
+        {
+            contract.authoritative_definitions =
+                serde_json::from_value(auth_defs.clone()).unwrap_or_default();
+        }
+        if let Some(tags) = first_table.odcl_metadata.get("contractTags") {
+            contract.tags = serde_json::from_value(tags.clone()).unwrap_or_default();
+        }
+        if let Some(custom) = first_table.odcl_metadata.get("contractCustomProperties") {
+            contract.custom_properties = serde_json::from_value(custom.clone()).unwrap_or_default();
+        }
+        if let Some(ts) = first_table
+            .odcl_metadata
+            .get("contractCreatedTs")
+            .and_then(|v| v.as_str())
+        {
+            contract.contract_created_ts = Some(ts.to_string());
+        }
+
+        // Convert each table to a schema object
+        contract.schema = tables.iter().map(SchemaObject::from).collect();
+
+        contract
+    }
+
+    /// Convert contract to TableData for API responses
+    pub fn to_table_data(&self) -> Vec<TableData> {
+        self.schema
+            .iter()
+            .enumerate()
+            .map(|(idx, schema)| {
+                let description_value = self
+                    .description
+                    .as_ref()
+                    .map(|d| serde_json::to_value(d).unwrap_or(serde_json::Value::Null));
+
+                TableData {
+                    table_index: idx,
+                    // Contract identity
+                    id: Some(self.id.clone()),
+                    name: Some(schema.name.clone()),
+                    api_version: Some(self.api_version.clone()),
+                    version: Some(self.version.clone()),
+                    status: self.status.clone(),
+                    kind: Some(self.kind.clone()),
+                    // Domain & organization
+                    domain: self.domain.clone(),
+                    data_product: self.data_product.clone(),
+                    tenant: self.tenant.clone(),
+                    // Description
+                    description: description_value,
+                    // Schema-level fields
+                    physical_name: schema.physical_name.clone(),
+                    physical_type: schema.physical_type.clone(),
+                    business_name: schema.business_name.clone(),
+                    data_granularity_description: schema.data_granularity_description.clone(),
+                    // Columns
+                    columns: schema
+                        .properties
+                        .iter()
+                        .map(property_to_column_data)
+                        .collect(),
+                    // Server configuration
+                    servers: self
+                        .servers
+                        .iter()
+                        .filter_map(|s| serde_json::to_value(s).ok())
+                        .collect(),
+                    // Team & support
+                    team: self
+                        .team
+                        .as_ref()
+                        .and_then(|t| serde_json::to_value(t).ok()),
+                    support: self
+                        .support
+                        .as_ref()
+                        .and_then(|s| serde_json::to_value(s).ok()),
+                    // Roles
+                    roles: self
+                        .roles
+                        .iter()
+                        .filter_map(|r| serde_json::to_value(r).ok())
+                        .collect(),
+                    // SLA & quality
+                    sla_properties: self
+                        .service_levels
+                        .iter()
+                        .filter_map(|s| serde_json::to_value(s).ok())
+                        .collect(),
+                    quality: self
+                        .quality
+                        .iter()
+                        .filter_map(|q| serde_json::to_value(q).ok())
+                        .filter_map(|v| v.as_object().cloned())
+                        .map(|m| m.into_iter().collect())
+                        .collect(),
+                    // Pricing
+                    price: self
+                        .price
+                        .as_ref()
+                        .and_then(|p| serde_json::to_value(p).ok()),
+                    // Tags & custom properties
+                    tags: self.tags.clone(),
+                    custom_properties: self
+                        .custom_properties
+                        .iter()
+                        .filter_map(|cp| serde_json::to_value(cp).ok())
+                        .collect(),
+                    authoritative_definitions: self
+                        .authoritative_definitions
+                        .iter()
+                        .filter_map(|ad| serde_json::to_value(ad).ok())
+                        .collect(),
+                    // Timestamps
+                    contract_created_ts: self.contract_created_ts.clone(),
+                    // Metadata
+                    odcs_metadata: std::collections::HashMap::new(),
+                }
+            })
+            .collect()
+    }
+}
+
+/// Helper function to convert Property to ColumnData
+fn property_to_column_data(prop: &Property) -> ColumnData {
+    ColumnData {
+        id: prop.id.clone(),
+        name: prop.name.clone(),
+        business_name: prop.business_name.clone(),
+        description: prop.description.clone(),
+        data_type: prop.logical_type.clone(),
+        physical_type: prop.physical_type.clone(),
+        physical_name: prop.physical_name.clone(),
+        logical_type_options: prop.logical_type_options.as_ref().map(|opts| {
+            ColumnLogicalTypeOptions {
+                min_length: opts.min_length,
+                max_length: opts.max_length,
+                pattern: opts.pattern.clone(),
+                format: opts.format.clone(),
+                minimum: opts.minimum.clone(),
+                maximum: opts.maximum.clone(),
+                exclusive_minimum: opts.exclusive_minimum.clone(),
+                exclusive_maximum: opts.exclusive_maximum.clone(),
+                precision: opts.precision,
+                scale: opts.scale,
+            }
+        }),
+        primary_key: prop.primary_key,
+        primary_key_position: prop.primary_key_position,
+        unique: prop.unique,
+        nullable: !prop.required,
+        partitioned: prop.partitioned,
+        partition_key_position: prop.partition_key_position,
+        clustered: prop.clustered,
+        classification: prop.classification.clone(),
+        critical_data_element: prop.critical_data_element,
+        encrypted_name: prop.encrypted_name.clone(),
+        transform_source_objects: prop.transform_source_objects.clone(),
+        transform_logic: prop.transform_logic.clone(),
+        transform_description: prop.transform_description.clone(),
+        examples: prop.examples.clone(),
+        default_value: prop.default_value.clone(),
+        relationships: prop
+            .relationships
+            .iter()
+            .map(|r| ColumnPropertyRelationship {
+                relationship_type: r.relationship_type.clone(),
+                to: r.to.clone(),
+            })
+            .collect(),
+        authoritative_definitions: prop
+            .authoritative_definitions
+            .iter()
+            .map(|d| ColumnAuthDef {
+                definition_type: d.definition_type.clone(),
+                url: d.url.clone(),
+            })
+            .collect(),
+        quality: if prop.quality.is_empty() {
+            None
+        } else {
+            Some(
+                prop.quality
+                    .iter()
+                    .filter_map(|q| serde_json::to_value(q).ok())
+                    .filter_map(|v| v.as_object().cloned())
+                    .map(|m| m.into_iter().collect())
+                    .collect(),
+            )
+        },
+        enum_values: if prop.enum_values.is_empty() {
+            None
+        } else {
+            Some(prop.enum_values.clone())
+        },
+        tags: prop.tags.clone(),
+        custom_properties: prop
+            .custom_properties
+            .iter()
+            .map(|cp| (cp.property.clone(), cp.value.clone()))
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_property_to_column_roundtrip() {
+        let prop = Property::new("email", "string")
+            .with_required(true)
+            .with_description("User email address")
+            .with_classification("pii");
+
+        let col = Column::from(&prop);
+        assert_eq!(col.name, "email");
+        assert_eq!(col.data_type, "string");
+        assert!(!col.nullable); // required -> not nullable
+        assert_eq!(col.description, "User email address");
+        assert_eq!(col.classification, Some("pii".to_string()));
+
+        let prop2 = Property::from(&col);
+        assert_eq!(prop2.name, "email");
+        assert_eq!(prop2.logical_type, "string");
+        assert!(prop2.required);
+        assert_eq!(prop2.description, Some("User email address".to_string()));
+    }
+
+    #[test]
+    fn test_schema_to_table_roundtrip() {
+        let schema = SchemaObject::new("users")
+            .with_physical_name("tbl_users")
+            .with_physical_type("table")
+            .with_business_name("User Accounts")
+            .with_description("User data")
+            .with_properties(vec![
+                Property::new("id", "integer").with_primary_key(true),
+                Property::new("email", "string").with_required(true),
+            ]);
+
+        let table = Table::from(&schema);
+        assert_eq!(table.name, "users");
+        assert_eq!(table.columns.len(), 2);
+        assert_eq!(
+            table
+                .odcl_metadata
+                .get("physicalName")
+                .and_then(|v| v.as_str()),
+            Some("tbl_users")
+        );
+
+        let schema2 = SchemaObject::from(&table);
+        assert_eq!(schema2.name, "users");
+        assert_eq!(schema2.physical_name, Some("tbl_users".to_string()));
+        assert_eq!(schema2.physical_type, Some("table".to_string()));
+        assert_eq!(schema2.properties.len(), 2);
+    }
+
+    #[test]
+    fn test_contract_to_tables_roundtrip() {
+        let contract = ODCSContract::new("test-contract", "1.0.0")
+            .with_domain("test")
+            .with_status("active")
+            .with_schema(
+                SchemaObject::new("orders")
+                    .with_physical_type("table")
+                    .with_properties(vec![
+                        Property::new("id", "integer").with_primary_key(true),
+                        Property::new("total", "number"),
+                    ]),
+            )
+            .with_schema(
+                SchemaObject::new("items")
+                    .with_physical_type("table")
+                    .with_properties(vec![Property::new("id", "integer").with_primary_key(true)]),
+            );
+
+        let tables = contract.to_tables();
+        assert_eq!(tables.len(), 2);
+        assert_eq!(tables[0].name, "orders");
+        assert_eq!(tables[1].name, "items");
+
+        // Check contract metadata is in tables
+        assert_eq!(
+            tables[0]
+                .odcl_metadata
+                .get("domain")
+                .and_then(|v| v.as_str()),
+            Some("test")
+        );
+
+        let contract2 = ODCSContract::from_tables(&tables);
+        assert_eq!(contract2.name, "test-contract");
+        assert_eq!(contract2.version, "1.0.0");
+        assert_eq!(contract2.domain, Some("test".to_string()));
+        assert_eq!(contract2.schema_count(), 2);
+    }
+
+    #[test]
+    fn test_nested_property_flattening() {
+        let schema = SchemaObject::new("events").with_properties(vec![
+            Property::new("id", "string"),
+            Property::new("address", "object").with_nested_properties(vec![
+                Property::new("street", "string"),
+                Property::new("city", "string"),
+            ]),
+        ]);
+
+        let table = Table::from(&schema);
+
+        // Should have flattened columns: id, address, address.street, address.city
+        let column_names: Vec<&str> = table.columns.iter().map(|c| c.name.as_str()).collect();
+        assert!(column_names.contains(&"id"));
+        assert!(column_names.contains(&"address"));
+        assert!(column_names.contains(&"address.street"));
+        assert!(column_names.contains(&"address.city"));
+    }
+
+    #[test]
+    fn test_to_table_data() {
+        let contract = ODCSContract::new("test", "1.0.0")
+            .with_domain("test-domain")
+            .with_schema(
+                SchemaObject::new("users")
+                    .with_description("User data")
+                    .with_properties(vec![
+                        Property::new("id", "integer").with_primary_key(true),
+                        Property::new("name", "string"),
+                    ]),
+            );
+
+        let table_data = contract.to_table_data();
+        assert_eq!(table_data.len(), 1);
+        assert_eq!(table_data[0].name, Some("users".to_string()));
+        // Schema-level description is stored in the schema, not propagated to TableData description
+        // TableData.description is contract-level description
+        assert_eq!(table_data[0].domain, Some("test-domain".to_string()));
+        assert_eq!(table_data[0].columns.len(), 2);
+    }
+}

--- a/crates/core/src/models/odcs/mod.rs
+++ b/crates/core/src/models/odcs/mod.rs
@@ -1,0 +1,65 @@
+//! ODCS Native Data Structures
+//!
+//! This module provides native Rust types that model the ODCS (Open Data Contract Standard)
+//! v3.1.0 specification accurately. These types preserve the three-level hierarchy:
+//!
+//! 1. **Contract Level** ([`ODCSContract`]) - Root document with metadata
+//! 2. **Schema Level** ([`SchemaObject`]) - Tables/views/topics within a contract
+//! 3. **Property Level** ([`Property`]) - Columns/fields within a schema
+//!
+//! ## Design Goals
+//!
+//! - **Zero data loss**: Full round-trip import/export without losing metadata
+//! - **Multi-table support**: Native support for contracts with multiple schema objects
+//! - **Nested properties**: Proper hierarchical representation for OBJECT and ARRAY types
+//! - **Format mapping**: Clean mapping from Avro, Protobuf, JSON Schema, OpenAPI via custom properties
+//! - **Backwards compatibility**: Converters to/from existing `Table`/`Column` types
+//!
+//! ## Example
+//!
+//! ```rust
+//! use data_modelling_core::models::odcs::{ODCSContract, SchemaObject, Property};
+//!
+//! // Create a contract with two tables
+//! let contract = ODCSContract::new("ecommerce", "1.0.0")
+//!     .with_domain("retail")
+//!     .with_status("active")
+//!     .with_schema(
+//!         SchemaObject::new("orders")
+//!             .with_physical_type("table")
+//!             .with_properties(vec![
+//!                 Property::new("id", "integer").with_primary_key(true),
+//!                 Property::new("customer_id", "integer").with_required(true),
+//!                 Property::new("total", "number"),
+//!             ])
+//!     )
+//!     .with_schema(
+//!         SchemaObject::new("order_items")
+//!             .with_physical_type("table")
+//!             .with_properties(vec![
+//!                 Property::new("id", "integer").with_primary_key(true),
+//!                 Property::new("order_id", "integer").with_required(true),
+//!                 Property::new("product_name", "string"),
+//!             ])
+//!     );
+//!
+//! assert_eq!(contract.schema_count(), 2);
+//! ```
+
+pub mod contract;
+pub mod converters;
+pub mod property;
+pub mod schema;
+pub mod supporting;
+
+// Re-export main types for convenience
+pub use contract::ODCSContract;
+pub use property::Property;
+pub use schema::SchemaObject;
+
+// Re-export supporting types
+pub use supporting::{
+    AuthoritativeDefinition, CustomProperty, Description, Link, LogicalTypeOptions, Price,
+    PropertyRelationship, QualityRule, Role, SchemaRelationship, Server, ServiceLevel,
+    StructuredDescription, Support, Team, TeamMember, Terms,
+};

--- a/crates/core/src/models/odcs/property.rs
+++ b/crates/core/src/models/odcs/property.rs
@@ -1,0 +1,524 @@
+//! Property type for ODCS native data structures
+//!
+//! Represents a column/field in an ODCS schema object with full support
+//! for nested properties (OBJECT and ARRAY types).
+
+use super::supporting::{
+    AuthoritativeDefinition, CustomProperty, LogicalTypeOptions, PropertyRelationship, QualityRule,
+};
+use serde::{Deserialize, Serialize};
+
+/// Property - one column in a schema object (ODCS v3.1.0)
+///
+/// Properties represent individual fields in a schema. They support nested
+/// structures through the `properties` field (for OBJECT types) and the
+/// `items` field (for ARRAY types).
+///
+/// # Example
+///
+/// ```rust
+/// use data_modelling_core::models::odcs::{Property, LogicalTypeOptions};
+///
+/// // Simple property
+/// let id_prop = Property::new("id", "integer")
+///     .with_primary_key(true)
+///     .with_required(true);
+///
+/// // Nested object property
+/// let address_prop = Property::new("address", "object")
+///     .with_nested_properties(vec![
+///         Property::new("street", "string"),
+///         Property::new("city", "string"),
+///         Property::new("zip", "string"),
+///     ]);
+///
+/// // Array property
+/// let tags_prop = Property::new("tags", "array")
+///     .with_items(Property::new("", "string"));
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Property {
+    // === Core Identity Fields ===
+    /// Stable technical identifier
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Property name
+    pub name: String,
+    /// Business name for the property
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub business_name: Option<String>,
+    /// Property description/documentation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    // === Type Information ===
+    /// Logical data type (e.g., "string", "integer", "number", "boolean", "object", "array")
+    pub logical_type: String,
+    /// Physical database type (e.g., "VARCHAR(100)", "BIGINT")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub physical_type: Option<String>,
+    /// Physical name in the data source
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub physical_name: Option<String>,
+    /// Additional type options (min/max length, pattern, precision, etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logical_type_options: Option<LogicalTypeOptions>,
+
+    // === Key Constraints ===
+    /// Whether the property is required (inverse of nullable)
+    #[serde(default)]
+    pub required: bool,
+    /// Whether this property is part of the primary key
+    #[serde(default)]
+    pub primary_key: bool,
+    /// Position in composite primary key, 1-based
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_key_position: Option<i32>,
+    /// Whether the property contains unique values
+    #[serde(default)]
+    pub unique: bool,
+
+    // === Partitioning & Clustering ===
+    /// Whether the property is used for partitioning
+    #[serde(default)]
+    pub partitioned: bool,
+    /// Position in partition key, 1-based
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partition_key_position: Option<i32>,
+    /// Whether the property is used for clustering
+    #[serde(default)]
+    pub clustered: bool,
+
+    // === Data Classification & Security ===
+    /// Data classification level (e.g., "confidential", "public")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classification: Option<String>,
+    /// Whether this is a critical data element
+    #[serde(default)]
+    pub critical_data_element: bool,
+    /// Name of the encrypted version of this property
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted_name: Option<String>,
+
+    // === Transformation Metadata ===
+    /// Source objects used in transformation
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transform_source_objects: Vec<String>,
+    /// Transformation logic/expression
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transform_logic: Option<String>,
+    /// Human-readable transformation description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transform_description: Option<String>,
+
+    // === Examples & Defaults ===
+    /// Example values for this property
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<serde_json::Value>,
+    /// Default value for the property
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<serde_json::Value>,
+
+    // === Relationships & References ===
+    /// Property-level relationships
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relationships: Vec<PropertyRelationship>,
+    /// Authoritative definitions
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authoritative_definitions: Vec<AuthoritativeDefinition>,
+
+    // === Quality & Validation ===
+    /// Quality rules and checks
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub quality: Vec<QualityRule>,
+    /// Enum values if this property is an enumeration type
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub enum_values: Vec<String>,
+
+    // === Tags & Custom Properties ===
+    /// Property-level tags
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// Custom properties for format-specific metadata
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_properties: Vec<CustomProperty>,
+
+    // === Nested Properties (for OBJECT/ARRAY types) ===
+    /// For ARRAY types: the item type definition
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Box<Property>>,
+    /// For OBJECT types: nested property definitions
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub properties: Vec<Property>,
+}
+
+impl Property {
+    /// Create a new property with the given name and logical type
+    pub fn new(name: impl Into<String>, logical_type: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            logical_type: logical_type.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set the property as required
+    pub fn with_required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+
+    /// Set the property as a primary key
+    pub fn with_primary_key(mut self, primary_key: bool) -> Self {
+        self.primary_key = primary_key;
+        self
+    }
+
+    /// Set the primary key position
+    pub fn with_primary_key_position(mut self, position: i32) -> Self {
+        self.primary_key_position = Some(position);
+        self
+    }
+
+    /// Set the property description
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the business name
+    pub fn with_business_name(mut self, business_name: impl Into<String>) -> Self {
+        self.business_name = Some(business_name.into());
+        self
+    }
+
+    /// Set the physical type
+    pub fn with_physical_type(mut self, physical_type: impl Into<String>) -> Self {
+        self.physical_type = Some(physical_type.into());
+        self
+    }
+
+    /// Set the physical name
+    pub fn with_physical_name(mut self, physical_name: impl Into<String>) -> Self {
+        self.physical_name = Some(physical_name.into());
+        self
+    }
+
+    /// Set nested properties (for OBJECT types)
+    pub fn with_nested_properties(mut self, properties: Vec<Property>) -> Self {
+        self.properties = properties;
+        self
+    }
+
+    /// Set items property (for ARRAY types)
+    pub fn with_items(mut self, items: Property) -> Self {
+        self.items = Some(Box::new(items));
+        self
+    }
+
+    /// Set enum values
+    pub fn with_enum_values(mut self, values: Vec<String>) -> Self {
+        self.enum_values = values;
+        self
+    }
+
+    /// Add a custom property
+    pub fn with_custom_property(mut self, property: CustomProperty) -> Self {
+        self.custom_properties.push(property);
+        self
+    }
+
+    /// Add a tag
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Set unique constraint
+    pub fn with_unique(mut self, unique: bool) -> Self {
+        self.unique = unique;
+        self
+    }
+
+    /// Set classification
+    pub fn with_classification(mut self, classification: impl Into<String>) -> Self {
+        self.classification = Some(classification.into());
+        self
+    }
+
+    /// Check if this property has nested structure (OBJECT or ARRAY type)
+    pub fn has_nested_structure(&self) -> bool {
+        !self.properties.is_empty() || self.items.is_some()
+    }
+
+    /// Check if this is an object type
+    pub fn is_object(&self) -> bool {
+        self.logical_type.to_lowercase() == "object"
+            || self.logical_type.to_lowercase() == "struct"
+            || !self.properties.is_empty()
+    }
+
+    /// Check if this is an array type
+    pub fn is_array(&self) -> bool {
+        self.logical_type.to_lowercase() == "array" || self.items.is_some()
+    }
+
+    /// Get all nested properties recursively, returning (path, property) pairs
+    /// Path uses dot notation for nested objects and `[]` for arrays
+    pub fn flatten_to_paths(&self) -> Vec<(String, &Property)> {
+        let mut result = Vec::new();
+        self.flatten_recursive(&self.name, &mut result);
+        result
+    }
+
+    fn flatten_recursive<'a>(
+        &'a self,
+        current_path: &str,
+        result: &mut Vec<(String, &'a Property)>,
+    ) {
+        // Add current property
+        result.push((current_path.to_string(), self));
+
+        // Recurse into nested object properties
+        for nested in &self.properties {
+            let nested_path = if current_path.is_empty() {
+                nested.name.clone()
+            } else {
+                format!("{}.{}", current_path, nested.name)
+            };
+            nested.flatten_recursive(&nested_path, result);
+        }
+
+        // Recurse into array items
+        if let Some(ref items) = self.items {
+            let items_path = if current_path.is_empty() {
+                "[]".to_string()
+            } else {
+                format!("{}.[]", current_path)
+            };
+            items.flatten_recursive(&items_path, result);
+        }
+    }
+
+    /// Create a property tree from a list of flattened columns with dot-notation names
+    ///
+    /// This reconstructs the hierarchical structure from paths like:
+    /// - "address.street" -> nested object
+    /// - "tags.[]" -> array items
+    /// - "items.[].name" -> array of objects
+    pub fn from_flat_paths(paths: &[(String, Property)]) -> Vec<Property> {
+        use std::collections::HashMap;
+
+        // Group by top-level name
+        let mut top_level: HashMap<String, Vec<(String, &Property)>> = HashMap::new();
+
+        for (path, prop) in paths {
+            let parts: Vec<&str> = path.split('.').collect();
+            if parts.is_empty() {
+                continue;
+            }
+
+            let top_name = parts[0].to_string();
+            let remaining_path = if parts.len() > 1 {
+                parts[1..].join(".")
+            } else {
+                String::new()
+            };
+
+            top_level
+                .entry(top_name)
+                .or_default()
+                .push((remaining_path, prop));
+        }
+
+        // Build properties from grouped paths
+        let mut result = Vec::new();
+        for (name, children) in top_level {
+            // Find the root property (empty remaining path)
+            let root = children
+                .iter()
+                .find(|(path, _)| path.is_empty())
+                .map(|(_, p)| (*p).clone());
+
+            let mut prop = root.unwrap_or_else(|| Property::new(&name, "object"));
+            prop.name = name;
+
+            // Process nested paths
+            let nested_paths: Vec<(String, Property)> = children
+                .iter()
+                .filter(|(path, _)| !path.is_empty())
+                .map(|(path, p)| (path.clone(), (*p).clone()))
+                .collect();
+
+            if !nested_paths.is_empty() {
+                // Check if it's an array type (has [] in path)
+                let has_array_items = nested_paths.iter().any(|(p, _)| p.starts_with("[]"));
+
+                if has_array_items {
+                    // Build array items
+                    let items_paths: Vec<(String, Property)> = nested_paths
+                        .iter()
+                        .filter(|(p, _)| p.starts_with("[]"))
+                        .map(|(p, prop)| {
+                            let remaining = if p == "[]" {
+                                String::new()
+                            } else {
+                                p.strip_prefix("[].").unwrap_or("").to_string()
+                            };
+                            (remaining, prop.clone())
+                        })
+                        .collect();
+
+                    if !items_paths.is_empty() {
+                        // Find the array item type
+                        let item_root = items_paths
+                            .iter()
+                            .find(|(p, _)| p.is_empty())
+                            .map(|(_, p)| p.clone());
+
+                        let mut items_prop =
+                            item_root.unwrap_or_else(|| Property::new("", "object"));
+
+                        // Recursively build nested items
+                        let nested_item_paths: Vec<(String, Property)> = items_paths
+                            .into_iter()
+                            .filter(|(p, _)| !p.is_empty())
+                            .collect();
+
+                        if !nested_item_paths.is_empty() {
+                            items_prop.properties = Property::from_flat_paths(&nested_item_paths);
+                        }
+
+                        prop.items = Some(Box::new(items_prop));
+                    }
+                }
+
+                // Build object properties (non-array paths)
+                let object_paths: Vec<(String, Property)> = nested_paths
+                    .into_iter()
+                    .filter(|(p, _)| !p.starts_with("[]"))
+                    .collect();
+
+                if !object_paths.is_empty() {
+                    prop.properties = Property::from_flat_paths(&object_paths);
+                }
+            }
+
+            result.push(prop);
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_property_creation() {
+        let prop = Property::new("id", "integer")
+            .with_primary_key(true)
+            .with_required(true)
+            .with_description("Unique identifier");
+
+        assert_eq!(prop.name, "id");
+        assert_eq!(prop.logical_type, "integer");
+        assert!(prop.primary_key);
+        assert!(prop.required);
+        assert_eq!(prop.description, Some("Unique identifier".to_string()));
+    }
+
+    #[test]
+    fn test_nested_object_property() {
+        let address = Property::new("address", "object").with_nested_properties(vec![
+            Property::new("street", "string"),
+            Property::new("city", "string"),
+            Property::new("zip", "string"),
+        ]);
+
+        assert!(address.is_object());
+        assert!(!address.is_array());
+        assert!(address.has_nested_structure());
+        assert_eq!(address.properties.len(), 3);
+    }
+
+    #[test]
+    fn test_array_property() {
+        let tags = Property::new("tags", "array").with_items(Property::new("", "string"));
+
+        assert!(tags.is_array());
+        assert!(!tags.is_object());
+        assert!(tags.has_nested_structure());
+        assert!(tags.items.is_some());
+    }
+
+    #[test]
+    fn test_flatten_to_paths() {
+        let address = Property::new("address", "object").with_nested_properties(vec![
+            Property::new("street", "string"),
+            Property::new("city", "string"),
+        ]);
+
+        let paths = address.flatten_to_paths();
+        assert_eq!(paths.len(), 3);
+        assert_eq!(paths[0].0, "address");
+        assert!(paths.iter().any(|(p, _)| p == "address.street"));
+        assert!(paths.iter().any(|(p, _)| p == "address.city"));
+    }
+
+    #[test]
+    fn test_flatten_array_to_paths() {
+        let items = Property::new("items", "array").with_items(
+            Property::new("", "object").with_nested_properties(vec![
+                Property::new("name", "string"),
+                Property::new("quantity", "integer"),
+            ]),
+        );
+
+        let paths = items.flatten_to_paths();
+        assert!(paths.iter().any(|(p, _)| p == "items"));
+        assert!(paths.iter().any(|(p, _)| p == "items.[]"));
+        assert!(paths.iter().any(|(p, _)| p == "items.[].name"));
+        assert!(paths.iter().any(|(p, _)| p == "items.[].quantity"));
+    }
+
+    #[test]
+    fn test_serialization() {
+        let prop = Property::new("name", "string")
+            .with_required(true)
+            .with_description("User name");
+
+        let json = serde_json::to_string_pretty(&prop).unwrap();
+        assert!(json.contains("\"name\": \"name\""));
+        assert!(json.contains("\"logicalType\": \"string\""));
+        assert!(json.contains("\"required\": true"));
+
+        // Verify camelCase
+        assert!(json.contains("logicalType"));
+        assert!(!json.contains("logical_type"));
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let json = r#"{
+            "name": "email",
+            "logicalType": "string",
+            "required": true,
+            "logicalTypeOptions": {
+                "format": "email",
+                "maxLength": 255
+            }
+        }"#;
+
+        let prop: Property = serde_json::from_str(json).unwrap();
+        assert_eq!(prop.name, "email");
+        assert_eq!(prop.logical_type, "string");
+        assert!(prop.required);
+        assert!(prop.logical_type_options.is_some());
+        let opts = prop.logical_type_options.unwrap();
+        assert_eq!(opts.format, Some("email".to_string()));
+        assert_eq!(opts.max_length, Some(255));
+    }
+}

--- a/crates/core/src/models/odcs/schema.rs
+++ b/crates/core/src/models/odcs/schema.rs
@@ -1,0 +1,369 @@
+//! SchemaObject type for ODCS native data structures
+//!
+//! Represents a table/view/topic in an ODCS contract with full support
+//! for all schema-level metadata fields.
+
+use super::property::Property;
+use super::supporting::{AuthoritativeDefinition, CustomProperty, QualityRule, SchemaRelationship};
+use serde::{Deserialize, Serialize};
+
+/// SchemaObject - one table/view/topic in a contract (ODCS v3.1.0)
+///
+/// Schema objects represent individual data structures within a contract.
+/// Each schema object contains properties (columns) and can have its own
+/// metadata like quality rules, relationships, and authoritative definitions.
+///
+/// # Example
+///
+/// ```rust
+/// use data_modelling_core::models::odcs::{SchemaObject, Property};
+///
+/// let users_table = SchemaObject::new("users")
+///     .with_physical_name("tbl_users")
+///     .with_physical_type("table")
+///     .with_business_name("User Accounts")
+///     .with_description("Contains registered user information")
+///     .with_properties(vec![
+///         Property::new("id", "integer").with_primary_key(true),
+///         Property::new("email", "string").with_required(true),
+///         Property::new("name", "string"),
+///     ]);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaObject {
+    // === Core Identity Fields ===
+    /// Stable technical identifier
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Schema object name (table/view name)
+    pub name: String,
+    /// Physical name in the data source
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub physical_name: Option<String>,
+    /// Physical type ("table", "view", "topic", "file", "object", "stream")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub physical_type: Option<String>,
+    /// Business name for the schema object
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub business_name: Option<String>,
+    /// Schema object description/documentation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    // === Granularity ===
+    /// Description of the data granularity (e.g., "One row per customer per day")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_granularity_description: Option<String>,
+
+    // === Properties (Columns) ===
+    /// List of properties/columns in this schema object
+    #[serde(default)]
+    pub properties: Vec<Property>,
+
+    // === Relationships ===
+    /// Schema-level relationships to other schema objects
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relationships: Vec<SchemaRelationship>,
+
+    // === Quality & Validation ===
+    /// Quality rules and checks at schema level
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub quality: Vec<QualityRule>,
+
+    // === References ===
+    /// Authoritative definitions for this schema object
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authoritative_definitions: Vec<AuthoritativeDefinition>,
+
+    // === Tags & Custom Properties ===
+    /// Schema-level tags
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// Custom properties for format-specific metadata
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_properties: Vec<CustomProperty>,
+}
+
+impl SchemaObject {
+    /// Create a new schema object with the given name
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set the physical name
+    pub fn with_physical_name(mut self, physical_name: impl Into<String>) -> Self {
+        self.physical_name = Some(physical_name.into());
+        self
+    }
+
+    /// Set the physical type
+    pub fn with_physical_type(mut self, physical_type: impl Into<String>) -> Self {
+        self.physical_type = Some(physical_type.into());
+        self
+    }
+
+    /// Set the business name
+    pub fn with_business_name(mut self, business_name: impl Into<String>) -> Self {
+        self.business_name = Some(business_name.into());
+        self
+    }
+
+    /// Set the description
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the data granularity description
+    pub fn with_data_granularity_description(mut self, description: impl Into<String>) -> Self {
+        self.data_granularity_description = Some(description.into());
+        self
+    }
+
+    /// Set the properties (columns)
+    pub fn with_properties(mut self, properties: Vec<Property>) -> Self {
+        self.properties = properties;
+        self
+    }
+
+    /// Add a property
+    pub fn with_property(mut self, property: Property) -> Self {
+        self.properties.push(property);
+        self
+    }
+
+    /// Set the relationships
+    pub fn with_relationships(mut self, relationships: Vec<SchemaRelationship>) -> Self {
+        self.relationships = relationships;
+        self
+    }
+
+    /// Add a relationship
+    pub fn with_relationship(mut self, relationship: SchemaRelationship) -> Self {
+        self.relationships.push(relationship);
+        self
+    }
+
+    /// Set the quality rules
+    pub fn with_quality(mut self, quality: Vec<QualityRule>) -> Self {
+        self.quality = quality;
+        self
+    }
+
+    /// Add a quality rule
+    pub fn with_quality_rule(mut self, rule: QualityRule) -> Self {
+        self.quality.push(rule);
+        self
+    }
+
+    /// Set the authoritative definitions
+    pub fn with_authoritative_definitions(
+        mut self,
+        definitions: Vec<AuthoritativeDefinition>,
+    ) -> Self {
+        self.authoritative_definitions = definitions;
+        self
+    }
+
+    /// Add an authoritative definition
+    pub fn with_authoritative_definition(mut self, definition: AuthoritativeDefinition) -> Self {
+        self.authoritative_definitions.push(definition);
+        self
+    }
+
+    /// Set the tags
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = tags;
+        self
+    }
+
+    /// Add a tag
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Set the custom properties
+    pub fn with_custom_properties(mut self, custom_properties: Vec<CustomProperty>) -> Self {
+        self.custom_properties = custom_properties;
+        self
+    }
+
+    /// Add a custom property
+    pub fn with_custom_property(mut self, custom_property: CustomProperty) -> Self {
+        self.custom_properties.push(custom_property);
+        self
+    }
+
+    /// Set the ID
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Get the primary key properties
+    pub fn primary_key_properties(&self) -> Vec<&Property> {
+        let mut pk_props: Vec<&Property> =
+            self.properties.iter().filter(|p| p.primary_key).collect();
+        pk_props.sort_by_key(|p| p.primary_key_position.unwrap_or(i32::MAX));
+        pk_props
+    }
+
+    /// Get the required properties
+    pub fn required_properties(&self) -> Vec<&Property> {
+        self.properties.iter().filter(|p| p.required).collect()
+    }
+
+    /// Get a property by name
+    pub fn get_property(&self, name: &str) -> Option<&Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    /// Get a mutable property by name
+    pub fn get_property_mut(&mut self, name: &str) -> Option<&mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
+    }
+
+    /// Count of properties
+    pub fn property_count(&self) -> usize {
+        self.properties.len()
+    }
+
+    /// Check if this schema has any nested/complex properties
+    pub fn has_nested_properties(&self) -> bool {
+        self.properties.iter().any(|p| p.has_nested_structure())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_schema_object_creation() {
+        let schema = SchemaObject::new("users")
+            .with_physical_name("tbl_users")
+            .with_physical_type("table")
+            .with_business_name("User Accounts")
+            .with_description("Contains user data");
+
+        assert_eq!(schema.name, "users");
+        assert_eq!(schema.physical_name, Some("tbl_users".to_string()));
+        assert_eq!(schema.physical_type, Some("table".to_string()));
+        assert_eq!(schema.business_name, Some("User Accounts".to_string()));
+        assert_eq!(schema.description, Some("Contains user data".to_string()));
+    }
+
+    #[test]
+    fn test_schema_with_properties() {
+        let schema = SchemaObject::new("orders").with_properties(vec![
+            Property::new("id", "integer")
+                .with_primary_key(true)
+                .with_primary_key_position(1),
+            Property::new("customer_id", "integer").with_required(true),
+            Property::new("total", "number"),
+        ]);
+
+        assert_eq!(schema.property_count(), 3);
+
+        let pk_props = schema.primary_key_properties();
+        assert_eq!(pk_props.len(), 1);
+        assert_eq!(pk_props[0].name, "id");
+
+        let required_props = schema.required_properties();
+        assert_eq!(required_props.len(), 1);
+        assert_eq!(required_props[0].name, "customer_id");
+    }
+
+    #[test]
+    fn test_get_property() {
+        let schema = SchemaObject::new("products")
+            .with_property(Property::new("id", "integer"))
+            .with_property(Property::new("name", "string"));
+
+        let id_prop = schema.get_property("id");
+        assert!(id_prop.is_some());
+        assert_eq!(id_prop.unwrap().name, "id");
+
+        let missing = schema.get_property("nonexistent");
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn test_serialization() {
+        let schema = SchemaObject::new("events")
+            .with_physical_type("topic")
+            .with_properties(vec![
+                Property::new("event_id", "string").with_primary_key(true),
+                Property::new("timestamp", "timestamp"),
+            ]);
+
+        let json = serde_json::to_string_pretty(&schema).unwrap();
+        assert!(json.contains("\"name\": \"events\""));
+        assert!(json.contains("\"physicalType\": \"topic\""));
+        assert!(json.contains("\"properties\""));
+
+        // Verify camelCase
+        assert!(json.contains("physicalType"));
+        assert!(!json.contains("physical_type"));
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let json = r#"{
+            "name": "customers",
+            "physicalName": "customer_table",
+            "physicalType": "table",
+            "businessName": "Customer Records",
+            "description": "All customer information",
+            "dataGranularityDescription": "One row per customer",
+            "properties": [
+                {
+                    "name": "id",
+                    "logicalType": "integer",
+                    "primaryKey": true
+                },
+                {
+                    "name": "email",
+                    "logicalType": "string",
+                    "required": true
+                }
+            ],
+            "tags": ["pii", "customer-data"]
+        }"#;
+
+        let schema: SchemaObject = serde_json::from_str(json).unwrap();
+        assert_eq!(schema.name, "customers");
+        assert_eq!(schema.physical_name, Some("customer_table".to_string()));
+        assert_eq!(schema.physical_type, Some("table".to_string()));
+        assert_eq!(schema.business_name, Some("Customer Records".to_string()));
+        assert_eq!(
+            schema.data_granularity_description,
+            Some("One row per customer".to_string())
+        );
+        assert_eq!(schema.properties.len(), 2);
+        assert_eq!(schema.tags, vec!["pii", "customer-data"]);
+    }
+
+    #[test]
+    fn test_has_nested_properties() {
+        let simple_schema = SchemaObject::new("simple")
+            .with_property(Property::new("id", "integer"))
+            .with_property(Property::new("name", "string"));
+
+        assert!(!simple_schema.has_nested_properties());
+
+        let nested_schema = SchemaObject::new("nested")
+            .with_property(Property::new("id", "integer"))
+            .with_property(
+                Property::new("address", "object")
+                    .with_nested_properties(vec![Property::new("city", "string")]),
+            );
+
+        assert!(nested_schema.has_nested_properties());
+    }
+}

--- a/crates/core/src/models/odcs/supporting.rs
+++ b/crates/core/src/models/odcs/supporting.rs
@@ -1,0 +1,529 @@
+//! Supporting types for ODCS native data structures
+//!
+//! These types are used across ODCSContract, SchemaObject, and Property
+//! to represent shared concepts like quality rules, custom properties, and relationships.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Quality rule for data validation (ODCS v3.1.0)
+///
+/// Quality rules can be defined at contract, schema, or property level.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct QualityRule {
+    /// Type of quality rule (e.g., "sql", "custom", "library")
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub rule_type: Option<String>,
+    /// Quality dimension (e.g., "accuracy", "completeness", "timeliness")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dimension: Option<String>,
+    /// Business impact description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub business_impact: Option<String>,
+    /// Metric name for the rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metric: Option<String>,
+    /// Description of the quality rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Condition that must be true
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_be: Option<serde_json::Value>,
+    /// Condition that must be false
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_not_be: Option<serde_json::Value>,
+    /// Greater than condition
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_be_greater_than: Option<serde_json::Value>,
+    /// Less than condition
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_be_less_than: Option<serde_json::Value>,
+    /// Greater than or equal condition
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_be_greater_than_or_equal: Option<serde_json::Value>,
+    /// Less than or equal condition
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_be_less_than_or_equal: Option<serde_json::Value>,
+    /// Value must be in this set
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_be_in: Option<Vec<serde_json::Value>>,
+    /// Value must not be in this set
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub must_not_be_in: Option<Vec<serde_json::Value>>,
+    /// SQL query for validation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    /// Scheduler type for quality checks
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduler: Option<String>,
+    /// Schedule expression
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<String>,
+    /// Engine for running the quality check
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub engine: Option<String>,
+    /// URL to quality tool or dashboard
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Additional properties not explicitly modeled
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Custom property for format-specific metadata (ODCS v3.1.0)
+///
+/// Used to store metadata that doesn't fit into the standard ODCS fields,
+/// such as Avro-specific or Protobuf-specific attributes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomProperty {
+    /// Property name
+    pub property: String,
+    /// Property value (flexible type)
+    pub value: serde_json::Value,
+}
+
+impl CustomProperty {
+    /// Create a new custom property
+    pub fn new(property: impl Into<String>, value: serde_json::Value) -> Self {
+        Self {
+            property: property.into(),
+            value,
+        }
+    }
+
+    /// Create a string custom property
+    pub fn string(property: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            property: property.into(),
+            value: serde_json::Value::String(value.into()),
+        }
+    }
+}
+
+/// Authoritative definition reference (ODCS v3.1.0)
+///
+/// Links to external authoritative sources for definitions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthoritativeDefinition {
+    /// Type of the reference (e.g., "businessDefinition", "transformationImplementation")
+    #[serde(rename = "type")]
+    pub definition_type: String,
+    /// URL to the authoritative definition
+    pub url: String,
+}
+
+impl AuthoritativeDefinition {
+    /// Create a new authoritative definition
+    pub fn new(definition_type: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            definition_type: definition_type.into(),
+            url: url.into(),
+        }
+    }
+}
+
+/// Schema-level relationship (ODCS v3.1.0)
+///
+/// Represents relationships between schema objects (tables).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaRelationship {
+    /// Relationship type (e.g., "foreignKey", "parent", "child")
+    #[serde(rename = "type")]
+    pub relationship_type: String,
+    /// Source properties (column names) in this schema
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub from_properties: Vec<String>,
+    /// Target schema object name
+    pub to_schema: String,
+    /// Target properties (column names) in the target schema
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub to_properties: Vec<String>,
+    /// Optional description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Property-level relationship (ODCS v3.1.0)
+///
+/// Represents relationships from a property to other definitions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertyRelationship {
+    /// Relationship type (e.g., "foreignKey", "parent", "child")
+    #[serde(rename = "type")]
+    pub relationship_type: String,
+    /// Target reference (e.g., "definitions/order_id", "schema/id/properties/id")
+    pub to: String,
+}
+
+impl PropertyRelationship {
+    /// Create a new property relationship
+    pub fn new(relationship_type: impl Into<String>, to: impl Into<String>) -> Self {
+        Self {
+            relationship_type: relationship_type.into(),
+            to: to.into(),
+        }
+    }
+}
+
+/// Logical type options for additional type metadata (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LogicalTypeOptions {
+    /// Minimum length for strings
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_length: Option<i64>,
+    /// Maximum length for strings
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<i64>,
+    /// Regex pattern for strings
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+    /// Format hint (e.g., "email", "uuid", "uri")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+    /// Minimum value for numbers/dates
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<serde_json::Value>,
+    /// Maximum value for numbers/dates
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<serde_json::Value>,
+    /// Exclusive minimum for numbers
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclusive_minimum: Option<serde_json::Value>,
+    /// Exclusive maximum for numbers
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclusive_maximum: Option<serde_json::Value>,
+    /// Precision for decimals
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub precision: Option<i32>,
+    /// Scale for decimals
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scale: Option<i32>,
+}
+
+impl LogicalTypeOptions {
+    /// Check if all options are empty/None
+    pub fn is_empty(&self) -> bool {
+        self.min_length.is_none()
+            && self.max_length.is_none()
+            && self.pattern.is_none()
+            && self.format.is_none()
+            && self.minimum.is_none()
+            && self.maximum.is_none()
+            && self.exclusive_minimum.is_none()
+            && self.exclusive_maximum.is_none()
+            && self.precision.is_none()
+            && self.scale.is_none()
+    }
+}
+
+/// Team information (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Team {
+    /// Team name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Team members
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub members: Vec<TeamMember>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Team member information
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamMember {
+    /// Member name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Member email
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// Member role
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Support information (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Support {
+    /// Support channel
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// Support URL
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Support email
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Server configuration (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Server {
+    /// Server name/identifier
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+    /// Server type (e.g., "BigQuery", "Snowflake", "S3")
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub server_type: Option<String>,
+    /// Server environment (e.g., "production", "development")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<String>,
+    /// Server description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Database name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
+    /// Project name (for cloud platforms)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    /// Schema name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    /// Catalog name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog: Option<String>,
+    /// Dataset name (for BigQuery)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dataset: Option<String>,
+    /// Account name (for Snowflake)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    /// Host URL
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    /// Location/Region
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    /// Format for file-based servers
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+    /// Delimiter for CSV files
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delimiter: Option<String>,
+    /// Topic name for streaming
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Role definition (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Role {
+    /// Role name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Role description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Principal (user/group)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal: Option<String>,
+    /// Access level
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Service level definition (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceLevel {
+    /// Service level property name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub property: Option<String>,
+    /// Value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+    /// Unit of measurement
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    /// Element this applies to
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub element: Option<String>,
+    /// Driver for this SLA
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+    /// Description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Scheduler
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduler: Option<String>,
+    /// Schedule expression
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Price information (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Price {
+    /// Price amount
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<serde_json::Value>,
+    /// Currency
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    /// Billing frequency
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub billing_frequency: Option<String>,
+    /// Price model type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_model: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Terms and conditions (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Terms {
+    /// Terms description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Usage limitations
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limitations: Option<String>,
+    /// URL to full terms
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Link to external resource (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Link {
+    /// Link type
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub link_type: Option<String>,
+    /// URL
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Description that can be string or structured object (ODCS v3.1.0)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum Description {
+    /// Simple string description
+    Simple(String),
+    /// Structured description object
+    Structured(StructuredDescription),
+}
+
+impl Default for Description {
+    fn default() -> Self {
+        Description::Simple(String::new())
+    }
+}
+
+impl Description {
+    /// Get the description as a simple string
+    pub fn as_string(&self) -> String {
+        match self {
+            Description::Simple(s) => s.clone(),
+            Description::Structured(d) => d.purpose.clone().unwrap_or_default(),
+        }
+    }
+}
+
+/// Structured description with multiple fields
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StructuredDescription {
+    /// Purpose of the data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+    /// Limitations of the data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limitations: Option<String>,
+    /// Usage guidelines
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<String>,
+    /// Additional properties
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quality_rule_serialization() {
+        let rule = QualityRule {
+            dimension: Some("accuracy".to_string()),
+            must_be: Some(serde_json::json!(true)),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&rule).unwrap();
+        assert!(json.contains("dimension"));
+        assert!(json.contains("accuracy"));
+    }
+
+    #[test]
+    fn test_custom_property() {
+        let prop = CustomProperty::string("source_format", "avro");
+        assert_eq!(prop.property, "source_format");
+        assert_eq!(prop.value, serde_json::json!("avro"));
+    }
+
+    #[test]
+    fn test_description_variants() {
+        let simple: Description = serde_json::from_str(r#""A simple description""#).unwrap();
+        assert_eq!(simple.as_string(), "A simple description");
+
+        let structured: Description =
+            serde_json::from_str(r#"{"purpose": "Data analysis", "usage": "Read-only"}"#).unwrap();
+        assert_eq!(structured.as_string(), "Data analysis");
+    }
+
+    #[test]
+    fn test_logical_type_options_is_empty() {
+        let empty = LogicalTypeOptions::default();
+        assert!(empty.is_empty());
+
+        let with_length = LogicalTypeOptions {
+            max_length: Some(100),
+            ..Default::default()
+        };
+        assert!(!with_length.is_empty());
+    }
+}

--- a/crates/odm/Cargo.toml
+++ b/crates/odm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odm"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-wasm"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Creates ODCS-native data structures (`ODCSContract`, `SchemaObject`, `Property`) that properly model the ODCS v3.1.0 three-level hierarchy. This enables lossless round-trip for all formats (ODCS, ODCL, Avro, Protobuf, JSON Schema, OpenAPI).

## Problem

Current `Table`/`Column` structs flatten ODCS's 3-level hierarchy:
- **Contract level** (apiVersion, domain, etc.) → catch-all `odcl_metadata` HashMap
- **Schema level** (physicalName, businessName) → partially lost
- **Property level** (columns) → mostly preserved but nested types use dot-notation

Result: Silent data loss on import, complex ~500 line reconstruction in export.

## Solution

### New Files Created

| File | Purpose |
|------|---------|
| `crates/core/src/models/odcs/mod.rs` | Module exports for all ODCS types |
| `crates/core/src/models/odcs/contract.rs` | `ODCSContract` struct with all contract-level fields |
| `crates/core/src/models/odcs/schema.rs` | `SchemaObject` struct with schema-level fields |
| `crates/core/src/models/odcs/property.rs` | `Property` struct with nested support (items/properties) |
| `crates/core/src/models/odcs/supporting.rs` | Supporting types (QualityRule, CustomProperty, etc.) |
| `crates/core/src/models/odcs/converters.rs` | `From` trait implementations for Table/Column interop |

### New v2 API Methods

**Import:**
- `ODCSImporter::import_contract()` - Returns native `ODCSContract` with nested properties

**Export:**
- `ODCSExporter::export_contract()` - Directly serializes `ODCSContract` to YAML
- `ODCSExporter::export_contract_validated()` - With optional schema validation

**WASM v2 Bindings:**
- `parse_odcs_yaml_v2()` - Returns `ODCSContract` JSON
- `export_odcs_yaml_v2()` - Takes `ODCSContract` JSON, returns YAML
- `odcs_contract_to_tables()` - Convert contract to Table array
- `tables_to_odcs_contract()` - Convert Table array to contract
- `odcs_contract_to_table_data()` - Convert contract to TableData for UI

### Backwards Compatibility

- All existing WASM functions (`parse_odcs_yaml`, `export_to_odcs_yaml`) unchanged
- Existing functions internally use converters to work with new types
- New v2 functions added alongside for clean API

## Test Results

- **186 unit tests** - All passing
- **80 doctests** - All passing

## Version

Bumped to **2.0.4**