### PR TITLE
chore: bump version to 2.0.6, fix crates.io publish timing

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -149,7 +149,7 @@ jobs:
           cd crates/core
           cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           echo "Waiting for crates.io to index the package..."
-          sleep 30
+          sleep 60
 
       - name: Publish data-modelling-sdk to crates.io
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6] - 2026-01-14
+
+### Fixed
+
+- **ci**: Increase crates.io indexing wait time to 60s to fix publish failures
+
 ## [2.0.5] - 2026-01-13
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/core", "crates/odm", "crates/wasm"]
 # Root package for backward compatibility - re-exports data-modelling-core
 [package]
 name = "data-modelling-sdk"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"
@@ -18,7 +18,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 # Re-export core library
-data-modelling-core = { path = "crates/core", version = "2.0.5" }
+data-modelling-core = { path = "crates/core", version = "2.0.6" }
 
 [features]
 default = ["api-backend"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-core"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/crates/odm/Cargo.toml
+++ b/crates/odm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odm"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-wasm"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps version to 2.0.6 and fixes the crates.io publish workflow.

## Changes

- Bump version from 2.0.5 to 2.0.6 in all Cargo.toml files
- Increase crates.io indexing wait time from 30s to 60s in release-sdk.yml
- Add CHANGELOG entry for 2.0.6

## Why

The 2.0.5 release failed because crates.io hadn't finished indexing `data-modelling-core` before `data-modelling-sdk` tried to publish (which depends on it).