### PR TITLE
fix(odcl): import model-level quality rules from ODCL Data Contract format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2026-01-14
+
+### Fixed
+
+- **fix(odcl)**: Import model-level quality rules from ODCL Data Contract format (#64)
+  - Fixed bug where `models.<name>.quality` rules were not being captured during ODCL import
+  - Quality rules are now extracted from both root level and model level in Data Contract Specification format
+  - Ensures all quality rules defined at the model level are preserved when converting ODCL to ODCS
+
+### Added
+
+- **test(odcl)**: Comprehensive E2E tests for ODCL import
+  - 13 new tests verifying ODCL to ODCS conversion preserves all fields
+  - Tests based on official datacontract-specification examples
+  - Coverage for: model-level quality, field-level quality, metadata, servicelevels, terms, servers, tags, column descriptions, $ref resolution, and roundtrip export
+
 ## [2.0.6] - 2026-01-14
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/core", "crates/odm", "crates/wasm"]
 # Root package for backward compatibility - re-exports data-modelling-core
 [package]
 name = "data-modelling-sdk"
-version = "2.0.6"
+version = "2.0.7"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-core"
-version = "2.0.6"
+version = "2.0.7"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/crates/odm/Cargo.toml
+++ b/crates/odm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odm"
-version = "2.0.6"
+version = "2.0.7"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-modelling-wasm"
-version = "2.0.6"
+version = "2.0.7"
 edition = "2024"
 authors = ["Mark Olliver"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Fixed bug where ODCL data quality rules were not being imported when converting to ODCS format.

### The Bug
In `crates/core/src/import/odcl.rs`, the `parse_data_contract` method was only extracting quality rules from the **root level** of the document, but in Data Contract Specification format, quality rules are defined at the **model level** (`models.<name>.quality`).

### The Fix
Modified `crates/core/src/import/odcl.rs` to extract quality rules from **both** the root level and the model level:
- Root-level quality rules (contract-level)
- Model-level quality rules (from `models.<name>.quality`)

### Tests Added
Added 13 comprehensive E2E tests in `crates/core/tests/odcs_comprehensive_tests.rs` under the `odcl_e2e_tests` module:

1. `test_odcl_import_model_level_quality_rules` - Verifies model-level quality rules are captured
2. `test_odcl_import_field_level_quality_rules` - Verifies field-level quality rules are captured
3. `test_odcl_import_preserves_info_metadata` - Verifies info section is preserved
4. `test_odcl_import_preserves_servicelevels` - Verifies servicelevels are preserved
5. `test_odcl_import_preserves_terms` - Verifies terms are preserved
6. `test_odcl_import_preserves_servers` - Verifies servers are preserved
7. `test_odcl_import_preserves_tags` - Verifies tags are preserved
8. `test_odcl_import_preserves_column_descriptions` - Verifies column descriptions
9. `test_odcl_import_resolves_definitions` - Verifies $ref definitions are resolved
10. `test_odcl_to_odcs_roundtrip_preserves_quality` - Verifies roundtrip export preserves quality
11. `test_odcl_import_handles_all_field_types` - Verifies all field types are imported
12. `test_odcl_import_via_sdk_import_method` - Tests the SDK import() API
13. `test_odcl_quality_rule_structure_preserved` - Verifies quality rule structure is preserved

All 47 comprehensive tests pass, and the full core package test suite (80+ tests) passes.

Fixes #64